### PR TITLE
API Auto Registration

### DIFF
--- a/java-rest-service/accelerator.yaml
+++ b/java-rest-service/accelerator.yaml
@@ -50,7 +50,31 @@ accelerator:
           text: Flyway (https://flywaydb.org/)
         - value: liquibase
           text: Liquibase (https://docs.liquibase.com/)
-
+    - name: exposeOpenAPIEndpoint
+      label: Expose OpenAPI endpoint?
+      dataType: boolean
+      defaultValue: false
+    - name: apiSystem
+      label: System API Belongs To
+      inputType: text
+      required: false
+      defaultValue: ''
+      dependsOn:
+        name: exposeOpenAPIEndpoint
+    - name: apiOwner
+      label: Owner of API
+      inputType: text
+      required: false
+      defaultValue: ''
+      dependsOn:
+        name: exposeOpenAPIEndpoint
+    - name: apiDescription
+      label: API Description
+      inputType: text
+      required: false
+      defaultValue: ''
+      dependsOn:
+        name: exposeOpenAPIEndpoint
   imports:
   - name: java-version
 
@@ -187,7 +211,22 @@ engine:
             substitutions:
               - text: "customerprofiledatabase"
                 with: "#databaseName"
-
+          - type: ReplaceText
+            condition: "#exposeOpenAPIEndpoint"
+            substitutions:
+              - text: "EXPOSE_ENDPOINT"
+                with: "\"true\""
+              - text: "#API_WORKLOAD_PARAMS"
+                with: "'  - name: api_descriptor\n    value:\n      type: openapi\n      location:\n        path: \"/v3/api-docs\"\n      owner: OWNER_VAL\n      system: SYSTEM_VAL\n      description: DESCRIPTION_VAL'"
+          - type: ReplaceText
+            condition: "#exposeOpenAPIEndpoint"
+            substitutions:
+              - text: "SYSTEM_VAL"
+                with: "#apiSystem"
+              - text: "OWNER_VAL"
+                with: "#apiOwner"
+              - text: "DESCRIPTION_VAL"
+                with: "#apiDescription"
     - merge:
       - type: InvokeFragment
         reference: java-version

--- a/java-rest-service/accelerator.yaml
+++ b/java-rest-service/accelerator.yaml
@@ -196,8 +196,27 @@ engine:
 
     - merge:
       - include: [ "**" ]
-        exclude: [ "config/postgres.yaml", "config/workload.yaml", "config/test-pipeline.yaml" ]
-      - include: [ "config/postgres.yaml", "config/workload.yaml", "config/test-pipeline.yaml" ]
+        exclude: [ "config/postgres.yaml", "config/workload-basic.yaml", "config/workload-api-provider.yaml", "config/test-pipeline.yaml" ]
+      - include: [ "config/workload-api-provider.yaml" ]
+        condition: "#exposeOpenAPIEndpoint"
+        chain:
+          - type: ReplaceText
+            condition: "#exposeOpenAPIEndpoint"
+            substitutions:
+              - text: "SYSTEM_VAL"
+                with: "#apiSystem"
+              - text: "OWNER_VAL"
+                with: "#apiOwner"
+              - text: "DESCRIPTION_VAL"
+                with: "#apiDescription"
+          - type: RewritePath
+            rewriteTo: "'config/workload.yaml'"
+      - include: [ "config/workload-basic.yaml" ]
+        condition: "!#exposeOpenAPIEndpoint"
+        chain:
+          - type: RewritePath
+            rewriteTo: "'config/workload.yaml'"
+      - include: [ "config/workload.yaml", "config/postgres.yaml", "config/test-pipeline.yaml" ]
         chain:
           - type: ReplaceText
             substitutions:
@@ -211,22 +230,6 @@ engine:
             substitutions:
               - text: "customerprofiledatabase"
                 with: "#databaseName"
-          - type: ReplaceText
-            condition: "#exposeOpenAPIEndpoint"
-            substitutions:
-              - text: "EXPOSE_ENDPOINT"
-                with: "\"true\""
-              - text: "#API_WORKLOAD_PARAMS"
-                with: "'  - name: api_descriptor\n    value:\n      type: openapi\n      location:\n        path: \"/v3/api-docs\"\n      owner: OWNER_VAL\n      system: SYSTEM_VAL\n      description: DESCRIPTION_VAL'"
-          - type: ReplaceText
-            condition: "#exposeOpenAPIEndpoint"
-            substitutions:
-              - text: "SYSTEM_VAL"
-                with: "#apiSystem"
-              - text: "OWNER_VAL"
-                with: "#apiOwner"
-              - text: "DESCRIPTION_VAL"
-                with: "#apiDescription"
     - merge:
       - type: InvokeFragment
         reference: java-version

--- a/java-rest-service/config/workload-api-provider.yaml
+++ b/java-rest-service/config/workload-api-provider.yaml
@@ -1,0 +1,37 @@
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: rest-service-db
+  labels:
+    apps.tanzu.vmware.com/workload-type: web
+    app.kubernetes.io/part-of: rest-service-db
+    apps.tanzu.vmware.com/has-tests: true
+    apis.apps.tanzu.vmware.com/register-api: "true"
+spec:
+  serviceClaims:
+    - name: db
+      ref:
+        apiVersion: sql.tanzu.vmware.com/v1
+        kind: Postgres
+        name: customer-profile-database
+  build:
+    env:
+      - name: BP_JVM_VERSION
+        value: "11"
+  params:
+    - name: annotations
+      value:
+        autoscaling.knative.dev/minScale: "1"
+    - name: api_descriptor
+      value:
+        type: openapi
+        location: 
+          path: "/v3/api-docs"
+        owner: OWNER_VAL
+        system: SYSTEM_VAL
+        description: DESCRIPTION_VAL
+  source:
+    git:
+      url: https://github.com/sample-accelerators/rest-service-db.git
+      ref:
+        branch: main

--- a/java-rest-service/config/workload-basic.yaml
+++ b/java-rest-service/config/workload-basic.yaml
@@ -6,7 +6,6 @@ metadata:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: rest-service-db
     apps.tanzu.vmware.com/has-tests: true
-    apis.apps.tanzu.vmware.com/register-api: "EXPOSE_ENDPOINT"
 spec:
   serviceClaims:
     - name: db
@@ -22,9 +21,9 @@ spec:
     - name: annotations
       value:
         autoscaling.knative.dev/minScale: "1"
-#API_WORKLOAD_PARAMS
   source:
     git:
-      url: https://github.com/sample-accelerators/rest-service-db.git
+      url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
+    subPath: java-rest-service

--- a/java-rest-service/config/workload.yaml
+++ b/java-rest-service/config/workload.yaml
@@ -6,6 +6,7 @@ metadata:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: rest-service-db
     apps.tanzu.vmware.com/has-tests: true
+    apis.apps.tanzu.vmware.com/register-api: "EXPOSE_ENDPOINT"
 spec:
   serviceClaims:
     - name: db
@@ -21,6 +22,7 @@ spec:
     - name: annotations
       value:
         autoscaling.knative.dev/minScale: "1"
+#API_WORKLOAD_PARAMS
   source:
     git:
       url: https://github.com/sample-accelerators/rest-service-db.git


### PR DESCRIPTION
Follow up from https://github.com/pivotal/acc-content/pull/35/files.  We updated the 

- removed 'display' option
- made 2 separate workload files and select the one to use based on whether or not api auto registration is selected