### PR TITLE
pivotal/acc-engine#222 - Use text replacement instead of OpenRewrite …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,39 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**
+!**/src/test/**
+bin/
+classes/
+target/
+*.log
+*.log.*
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
 ### VS Code ###
 .vscode/
+
+### Mac ###
+.DS_Store

--- a/java-rest-service/accelerator.yaml
+++ b/java-rest-service/accelerator.yaml
@@ -143,11 +143,10 @@ engine:
           exclude: [ "pom.xml", "build.gradle.kts", "**/application.properties" ]
         - include: [ "pom.xml" ]
           chain:
-            - type: OpenRewriteRecipe
-              recipe: org.openrewrite.maven.RemoveDependency
-              options:
-                groupId: "'org.liquibase'"
-                artifactId: "'liquibase-core'"
+            - type: ReplaceText
+              regex:
+                pattern: "<dependency>\\s+<groupId>org\\.liquibase</groupId>\\s+<artifactId>liquibase-core</artifactId>\\s+</dependency>\\s+"
+                with: "''"
         - include: [ "build.gradle.kts" ]
           chain:
             - type: ReplaceText
@@ -175,11 +174,10 @@ engine:
           exclude: [ "pom.xml", "build.gradle.kts", "**/application.properties" ]
         - include: [ "pom.xml" ]
           chain:
-            - type: OpenRewriteRecipe
-              recipe: org.openrewrite.maven.RemoveDependency
-              options:
-                groupId: "'org.flywaydb'"
-                artifactId: "'flyway-core'"
+            - type: ReplaceText
+              regex:
+                pattern: "<dependency>\\s+<groupId>org\\.flywaydb</groupId>\\s+<artifactId>flyway-core</artifactId>\\s+</dependency>\\s+"
+                with: "''"
         - include: [ "build.gradle.kts" ]
           chain:
             - type: ReplaceText


### PR DESCRIPTION
…RemoveDependency recipe as the later one tries to resolve all dependencies while parsing pom.xml, what doesn't work in an air-gapped environment. Extend .gitignore to cover most common cases.

Co-authored-by: Jelle Aret <jaret@vmware.com>