### PR TITLE
Integrate tap-workload fragment to support GIT repository creation feature.

### DIFF
--- a/appsso-starter-java/accelerator.yaml
+++ b/appsso-starter-java/accelerator.yaml
@@ -8,3 +8,12 @@ accelerator:
     - openid
     - spring
     - java
+  imports:
+    - name: tap-workload
+
+engine:
+  merge:
+  - type: InvokeFragment
+    reference: tap-workload
+  - include: [ "**" ]
+  onConflict: UseFirst

--- a/java-function/accelerator.yaml
+++ b/java-function/accelerator.yaml
@@ -39,26 +39,9 @@ accelerator:
     inputType: checkbox
     dataType: boolean
     defaultValue: true
-    
-  - name: gitUrl
-    label: Git Repository URL
-    description: Change this to the Git repository you will use to store this function's files
-    inputType: text
-    dependsOn:
-      name: includeTap
-    dataType: string
-    required: true
-    defaultValue: "https://github.com/vmware-tanzu/application-accelerator-samples.git"
-    
-  - name: gitBranch
-    label: Git Repository Branch
-    description: The corresponding branch of the Git repository
-    inputType: text
-    dependsOn:
-      name: includeTap
-    dataType: string
-    required: true
-    defaultValue: "main"
+
+  imports:
+    - name: tap-workload
 
 engine:
   merge:
@@ -124,14 +107,15 @@ engine:
       chain:
         - type: ReplaceText
           substitutions:
-            - text: https://github.com/vmware-tanzu/application-accelerator-samples.git
-              with: "#gitUrl"
-            - text: main
-              with: "#gitBranch"
             - text: java-function
               with: "#artifactId"
         - type: RewritePath
           rewriteTo: "'config/' + #filename"
+        - merge:
+            - type: InvokeFragment
+              reference: tap-workload
+            - include: [ "**" ]
+          onConflict: UseFirst
     - include: [ "catalog/catalog-info.yaml" ]
       condition: "#includeTap"
       chain:

--- a/node-express/accelerator.yaml
+++ b/node-express/accelerator.yaml
@@ -15,6 +15,9 @@ accelerator:
     dataType: boolean
     defaultValue: true
 
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
     - include: [ "**" ]
@@ -32,6 +35,11 @@ engine:
         substitutions:
         - text: node-express
           with: "#artifactId"
+      - merge:
+          - type: InvokeFragment
+            reference: tap-workload
+          - include: [ "**" ]
+        onConflict: UseFirst
     - include: [ "catalog/catalog-info.yaml" ]
       condition: "#includeTap"
       chain:

--- a/node-function/accelerator.yaml
+++ b/node-function/accelerator.yaml
@@ -17,6 +17,9 @@ accelerator:
     dataType: boolean
     defaultValue: true
 
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
     - include: [ "**" ]
@@ -34,6 +37,11 @@ engine:
         substitutions:
         - text: node-function
           with: "#artifactId"
+      - merge:
+          - type: InvokeFragment
+            reference: tap-workload
+          - include: [ "**" ]
+        onConflict: UseFirst
     - include: [ "catalog/catalog-info.yaml" ]
       condition: "#includeTap"
       chain:

--- a/node-function/config/workload.yaml
+++ b/node-function/config/workload.yaml
@@ -12,3 +12,4 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
+    subPath: node-function

--- a/python-function/accelerator.yaml
+++ b/python-function/accelerator.yaml
@@ -33,28 +33,9 @@ accelerator:
     inputType: checkbox
     dataType: boolean
     defaultValue: true
-    
-  - name: gitUrl
-    label: Git Repository URL
-    display: true
-    description: Change this to the Git repository you will use to store this accelerator's files
-    inputType: text
-    dependsOn:
-      name: includeTap
-    dataType: string
-    required: true
-    defaultValue: "https://github.com/vmware-tanzu/application-accelerator-samples.git"
-    
-  - name: gitBranch
-    label: Git Repository Branch
-    display: true
-    description: The corresponding branch of the Git repository
-    inputType: text
-    dependsOn:
-      name: includeTap
-    dataType: string
-    required: true
-    defaultValue: "main"
+
+  imports:
+    - name: tap-workload
 
 engine:
   merge:
@@ -97,12 +78,13 @@ engine:
           substitutions:
             - text: python-function
               with: "#artifactId"
-            - text: https://github.com/vmware-tanzu/application-accelerator-samples.git
-              with: "#gitUrl"
-            - text: main
-              with: "#gitBranch"
         - type: RewritePath
           rewriteTo: "'config/' + #filename"
+        - merge:
+            - type: InvokeFragment
+              reference: tap-workload
+            - include: [ "**" ]
+          onConflict: UseFirst
     - include: [ "catalog/catalog-info.yaml" ]
       condition: "#includeTap"
       chain:

--- a/python-function/config/workload.yaml
+++ b/python-function/config/workload.yaml
@@ -12,3 +12,4 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
+    subPath: python-function

--- a/spring-cloud-serverless/accelerator.yaml
+++ b/spring-cloud-serverless/accelerator.yaml
@@ -33,6 +33,7 @@ accelerator:
       value: workload
   imports:
   - name: java-version
+  - name: tap-workload
 
 engine:
   chain:
@@ -72,6 +73,11 @@ engine:
           with: "': ' + #artifactId"
       - type: RewritePath
         rewriteTo: "'config/' + #filename"
+      - merge:
+          - type: InvokeFragment
+            reference: tap-workload
+          - include: [ "**" ]
+        onConflict: UseFirst
     - include: [ "kubernetes/tap/Tiltfile" ]
       condition: "#deploymentType == 'workload'"
       chain:

--- a/tanzu-java-web-app/accelerator.yaml
+++ b/tanzu-java-web-app/accelerator.yaml
@@ -14,11 +14,11 @@ accelerator:
     label: Prefix for the container image repository
     defaultValue: dev.local
     required: true
+
   imports:
   - name: tap-workload
 
 engine:
-  onConflict: NWayDiff
   merge:
   - include: [ "**/*" ]
     exclude: [ "config/*.yaml", "Tiltfile", "README.md", "grype.yaml", "catalog/*.yaml", ".github/workflows/**" ]
@@ -40,9 +40,9 @@ engine:
       - text: ": tanzu-java-web-app"
         with: "': ' + #artifactId.toLowerCase()"
     - merge:
-        - type: InvokeFragment
-          reference: tap-workload
-        - include: [ "**" ]
+      - type: InvokeFragment
+        reference: tap-workload
+      - include: [ "**" ]
       onConflict: UseFirst
 
   - include: [ "README.md" ]
@@ -57,5 +57,3 @@ engine:
       substitutions:
       - text: tanzu-java-web-app
         with: "#artifactId"
-    - type: RewritePath
-      rewriteTo: "#filename"

--- a/tap-initialize/accelerator.yaml
+++ b/tap-initialize/accelerator.yaml
@@ -13,7 +13,10 @@ accelerator:
 
   imports:
     - name: tap-initialize
+      expose:
+        - name: "includeHasTests"
     - name: live-update
+    - name: tap-workload
 
 engine:
   merge:
@@ -25,11 +28,21 @@ engine:
           substitutions:
             - text: my-project
               with: "#targetProject"
-    - type: InvokeFragment
-      let:
-      - name: artifactId
-        expression: "#targetProject"
-      reference: tap-initialize
+
+    - chain:
+      - type: InvokeFragment
+        let:
+        - name: artifactId
+          expression: "#targetProject"
+        - name: gitRepository
+          expression: "'https://git.example.com/my-repo'"
+        reference: tap-initialize
+      - merge:
+          - type: InvokeFragment
+            reference: tap-workload
+          - include: [ "**" ]
+        onConflict: UseFirst
+
     - type: InvokeFragment
       let:
       - name: artifactId

--- a/weatherforecast-csharp/accelerator.yaml
+++ b/weatherforecast-csharp/accelerator.yaml
@@ -13,6 +13,10 @@ accelerator:
     inputType: text
     defaultValue: Sample
     required: true
+
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
   - include: [ "**" ]
@@ -32,3 +36,8 @@ engine:
       substitutions:
       - text: sample-app
         with: "#artifactId.toLowerCase()"
+    - merge:
+      - type: InvokeFragment
+        reference: tap-workload
+      - include: [ "**" ]
+      onConflict: UseFirst

--- a/weatherforecast-steeltoe/accelerator.yaml
+++ b/weatherforecast-steeltoe/accelerator.yaml
@@ -17,6 +17,9 @@ accelerator:
     defaultValue: Sample
     required: true
 
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
   - include: [ "**" ]
@@ -38,3 +41,8 @@ engine:
         with: "#artifactId.toLowerCase()"
       - text: Sample
         with: "#applicationName"
+    - merge:
+      - type: InvokeFragment
+        reference: tap-workload
+      - include: [ "**" ]
+      onConflict: UseFirst


### PR DESCRIPTION
All accelerators are changed, except the following, as those are multi module projects which need `subPath` feature to work:
- `hungryman`
- `spring-smtp-gateway`