### PR TITLE
Removing namespace from individual apps workload.yaml files.

### DIFF
--- a/spring-smtp-gateway/smtp-gateway/config/workload.yaml
+++ b/spring-smtp-gateway/smtp-gateway/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: smtp-gateway
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: server
     app.kubernetes.io/part-of: spring-smtp-gateway

--- a/spring-smtp-gateway/smtp-sink/config/workload.yaml
+++ b/spring-smtp-gateway/smtp-sink/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: smtp-sink
-  namespace: workloads  
   labels:
     apps.tanzu.vmware.com/workload-type: worker
     app.kubernetes.io/part-of: spring-smtp-gateway

--- a/where-for-dinner/accelerator.yaml
+++ b/where-for-dinner/accelerator.yaml
@@ -140,8 +140,8 @@ accelerator:
     dependsOn: 
       name: enableDefaultDevAccount
   - label: Dev Account BCrypt Password
-    description: "A BCrypted version of the password.  You can use the following online tool to create a bycrypt string: https://www.browserling.com/tools/bcrypt"
-    defaultValue: "$2a$10$J/EWz6Q8zxRHYCr2UwJewe5hN6uKhbytUuGGC2yHvEJ2zhH.dLvZe"
+    description: "Plain text version of the dev password."
+    defaultValue: "letseat"
     name: devDefaultAccountPassword
     inputType: text
     dataType: string

--- a/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: where-for-dinner
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner

--- a/where-for-dinner/where-for-dinner-availability/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-availability/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: where-for-dinner-notify
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner

--- a/where-for-dinner/where-for-dinner-notify/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-notify/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: where-for-dinner-notify
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner

--- a/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: where-for-dinner-search-proc
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner

--- a/where-for-dinner/where-for-dinner-search/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search/config/workload.yaml
@@ -2,7 +2,6 @@ apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: where-for-dinner-search
-  namespace: workloads
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner


### PR DESCRIPTION
Serveral of the "Where for Dinner" and SMTP gateway workloads had namespace attributes in the individual services' workload.yaml file.

Also updated the "Where for Dinner" acclerator's SSO option to use a plain text password vs a BCrypt password.  BCrypt support is no longer available in AppSSO 2.0 (listed as a breaking change).