### PR TITLE
Removed the subPath in TAP workload.yaml for non-mono repositories

### DIFF
--- a/appsso-starter-java/config/workload.yaml
+++ b/appsso-starter-java/config/workload.yaml
@@ -20,4 +20,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: appsso-starter-java

--- a/java-rest-service/config/workload-api-provider.yaml
+++ b/java-rest-service/config/workload-api-provider.yaml
@@ -29,4 +29,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: java-rest-service

--- a/java-rest-service/config/workload-basic.yaml
+++ b/java-rest-service/config/workload-basic.yaml
@@ -20,4 +20,3 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: java-rest-service

--- a/java-server-side-ui/config/workload.yaml
+++ b/java-server-side-ui/config/workload.yaml
@@ -20,4 +20,3 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: java-server-side-ui

--- a/node-express/config/workload.yaml
+++ b/node-express/config/workload.yaml
@@ -12,4 +12,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: node-express

--- a/node-function/config/workload.yaml
+++ b/node-function/config/workload.yaml
@@ -11,4 +11,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: node-function

--- a/python-function/config/workload.yaml
+++ b/python-function/config/workload.yaml
@@ -11,4 +11,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: python-function

--- a/spring-cloud-serverless/kubernetes/tap/workload.yaml
+++ b/spring-cloud-serverless/kubernetes/tap/workload.yaml
@@ -15,4 +15,3 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: spring-cloud-serverless

--- a/spring-smtp-gateway/smtp-gateway/config/workload.yaml
+++ b/spring-smtp-gateway/smtp-gateway/config/workload.yaml
@@ -17,7 +17,7 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: spring-smtp-gateway/smtp-gateway
+    subPath: smtp-gateway
   params:
   - name: ports
     value:

--- a/spring-smtp-gateway/smtp-sink/config/workload.yaml
+++ b/spring-smtp-gateway/smtp-sink/config/workload.yaml
@@ -17,4 +17,4 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: spring-smtp-gateway/smtp-sink
+    subPath: smtp-sink

--- a/spring-smtp-gateway/templates/workloads.template
+++ b/spring-smtp-gateway/templates/workloads.template
@@ -19,7 +19,7 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: spring-smtp-gateway/smtp-gateway
+    subPath: smtp-gateway
   params:
   - name: ports
     value:
@@ -47,4 +47,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: spring-smtp-gateway/smtp-sink
+    subPath: smtp-sink

--- a/tanzu-java-web-app/config/workload.yaml
+++ b/tanzu-java-web-app/config/workload.yaml
@@ -15,4 +15,3 @@ spec:
       ref:
         branch: main
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
-    subPath: tanzu-java-web-app

--- a/weatherforecast-csharp/config/workload.yaml
+++ b/weatherforecast-csharp/config/workload.yaml
@@ -11,4 +11,3 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: weatherforecast-csharp

--- a/weatherforecast-steeltoe/config/workload.yaml
+++ b/weatherforecast-steeltoe/config/workload.yaml
@@ -14,4 +14,3 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: weatherforecast-steeltoe

--- a/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
@@ -15,4 +15,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-api-gateway
+    subPath: where-for-dinner-api-gateway

--- a/where-for-dinner/where-for-dinner-availability/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-availability/config/workload.yaml
@@ -1,7 +1,7 @@
 apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
-  name: where-for-dinner-notify
+  name: where-for-dinner-availability
   labels:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: where-for-dinner
@@ -21,4 +21,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-notify
+    subPath: where-for-dinner-availability

--- a/where-for-dinner/where-for-dinner-crawler/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-crawler/config/workload.yaml
@@ -15,4 +15,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-crawler
+    subPath: where-for-dinner-crawler

--- a/where-for-dinner/where-for-dinner-notify/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-notify/config/workload.yaml
@@ -22,4 +22,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-notify
+    subPath: where-for-dinner-notify

--- a/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
@@ -22,4 +22,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-search-proc
+    subPath: where-for-dinner-search-proc

--- a/where-for-dinner/where-for-dinner-search/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search/config/workload.yaml
@@ -22,4 +22,4 @@ spec:
       url: https://github.com/vmware-tanzu/application-accelerator-samples.git
       ref:
         branch: main
-    subPath: where-for-dinner/where-for-dinner-search
+    subPath: where-for-dinner-search


### PR DESCRIPTION
For mono repositories changed the `subPath` to not take into account the parent directory (which would not exist in target repository/file-system structure after generation).