### PR TITLE
Changed name and label of Tekton Test pipeline for Tanzu Java Rest Service

### DIFF
--- a/java-rest-service/config/test-pipeline.yaml
+++ b/java-rest-service/config/test-pipeline.yaml
@@ -1,9 +1,9 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: rest-service-db-test-pipeline
+  name: java-test-pipeline
   labels:
-    apps.tanzu.vmware.com/pipeline: test
+    apps.tanzu.vmware.com/pipeline: test-java
 spec:
   params:
     - name: source-url

--- a/java-rest-service/config/workload-api-provider.yaml
+++ b/java-rest-service/config/workload-api-provider.yaml
@@ -16,6 +16,9 @@ spec:
     - name: annotations
       value:
         autoscaling.knative.dev/minScale: "1"
+    - name: testing_pipeline_matching_labels
+      value:
+        apps.tanzu.vmware.com/pipeline: test-java
     - name: api_descriptor
       value:
         type: openapi

--- a/java-rest-service/config/workload-basic.yaml
+++ b/java-rest-service/config/workload-basic.yaml
@@ -15,6 +15,9 @@ spec:
     - name: annotations
       value:
         autoscaling.knative.dev/minScale: "1"
+    - name: testing_pipeline_matching_labels
+      value:
+        apps.tanzu.vmware.com/pipeline: test-java
   source:
     git:
       url: <https URL for your generated project's Git repository>


### PR DESCRIPTION
and referred to this one from the workload definition. This allows users to have multiple Tekton (Test) pipelines provisioned on a TAP build/iterate cluster, as the 'test' label is too generic.