### PR TITLE
Adjust 'tap-workload' Fragment to support multi-module repos by no deleting a 'source.git.subPath' property from workload.yaml.

### DIFF
--- a/fragments/tap-workload/accelerator.yaml
+++ b/fragments/tap-workload/accelerator.yaml
@@ -1,26 +1,16 @@
 engine:
+  let:
+    - name: repoUrl
+      expression: "T(org.springframework.web.util.UriComponentsBuilder).fromUriString('https://' + #bsGitRepository).build(true)"
+  condition: "#bsGitRepository != null"
+  applyTo: [ "**/workload.yaml", "**/workloads.yaml" ]
   chain:
-    - condition: "#bsGitRepository != null"
-      chain:
-      - includes: [ "**/workload.yaml" ]
-        let:
-          - name: repoUrl
-            expression: "T(org.springframework.web.util.UriComponentsBuilder).fromUriString('https://' + #bsGitRepository).build(true)"
-        chain:
-          - type: OpenRewriteRecipe
-            recipe: org.openrewrite.yaml.ChangeValue
-            options:
-              oldKeyPath: '"$.spec.source.git.url"'
-              value: "#repoUrl.scheme + '://' + #repoUrl.host + '/' + #repoUrl.queryParams['owner'][0] + '/' + #repoUrl.queryParams['repo'][0]"
-          - type: ReplaceText
-            regex:
-              pattern: "(?<beforeBranch>[\\s\\S]+)(?<branch>branch: [\\S]+)(?<rest>[\\S\\s]*)"
-              with: "'${beforeBranch}branch: ' + #bsGitBranch + '${rest}'"
-          - type: ReplaceText
-            regex:
-              pattern: "(?<beforeSubPath>[\\s\\S]+)(?<subPath>subPath: [\\S]+)(?<rest>[\\S\\s]*)"
-              with: "'${beforeSubPath}${rest}'"
-
-    - condition: "#bsGitRepository == null"
-      type: Exclude
-      patterns: [ "**" ]
+    - type: OpenRewriteRecipe
+      recipe: org.openrewrite.yaml.ChangeValue
+      options:
+        oldKeyPath: '"$.spec.source.git.url"'
+        value: "#repoUrl.scheme + '://' + #repoUrl.host + '/' + #repoUrl.queryParams['owner'][0] + '/' + #repoUrl.queryParams['repo'][0]"
+    - type: ReplaceText
+      regex:
+        pattern: "(?<beforeBranch>[\\s\\S]+)(?<branch>branch: [\\S]+)(?<rest>[\\S\\s]*)"
+        with: "'${beforeBranch}branch: ' + #bsGitBranch + '${rest}'"

--- a/spring-smtp-gateway/accelerator.yaml
+++ b/spring-smtp-gateway/accelerator.yaml
@@ -66,6 +66,9 @@ accelerator:
     inputType: checkbox
     dataType: boolean
     required: true
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
   - exclude: 
@@ -91,6 +94,8 @@ engine:
     - type: RewritePath
       regex: 'templates/workloads.template'
       rewriteTo: "'config/developer/workloads.yaml'"
+    - type: InvokeFragment
+      reference: tap-workload
   - include: [ "**/catalog/catalog.yaml" ]
     chain:
       - type: ReplaceText

--- a/where-for-dinner/accelerator.yaml
+++ b/where-for-dinner/accelerator.yaml
@@ -151,17 +151,21 @@ accelerator:
     required: false
     dependsOn: 
       name: enableDefaultDevAccount
-     
+  imports:
+    - name: tap-workload
+
 engine:
   merge:
   - exclude: 
       ["**/templates/**", "**/icons/**", "**/.git/**", "**/deployment/**"]
   - include: ["**/templates/workloads.yaml"]
     chain:
-    - type: YTT  
+    - type: YTT
     - type: RewritePath
       regex: 'templates/workloads.yaml'
       rewriteTo: "'config/developer/workloads.yaml'"                  
+    - type: InvokeFragment
+      reference: tap-workload
   - include: ["**/rmqCluster.yaml"]
     chain:
     - type: YTT  


### PR DESCRIPTION
Apply it to 'where-for-dinner' and 'spring-smtp-gateway' Accelerator.
