### PR TITLE
Fix python function name replacement in workload.yaml

### DIFF
--- a/python-function/accelerator.yaml
+++ b/python-function/accelerator.yaml
@@ -15,7 +15,7 @@ accelerator:
   - name: functionName
     inputType: text
     label: Default function name
-    defaultValue: hello
+    defaultValue: main
     required: true
     
   - name: interfaceType
@@ -79,6 +79,8 @@ engine:
           substitutions:
             - text: python-function
               with: "#artifactId"
+            - text: main
+              with: "#functionName"
         - type: RewritePath
           rewriteTo: "'config/' + #filename"
         - merge:


### PR DESCRIPTION
When the python-function accelerator was generating a config/workload.yaml file, it was not setting the BP_FUNCTION environment variable to the provided "Default function name". 
