### PR TITLE
Updating app.kubernetes.io/part-of labels in where for dinner apps.

### DIFF
--- a/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-api-gateway/config/workload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: where-for-dinner
   labels:
     apps.tanzu.vmware.com/workload-type: web
-    app.kubernetes.io/part-of: where-for-dinner
+    app.kubernetes.io/part-of: where-for-dinner-api-gateway
 spec:
   params:
   - name: annotations

--- a/where-for-dinner/where-for-dinner-availability/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-availability/config/workload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: where-for-dinner-availability
   labels:
     apps.tanzu.vmware.com/workload-type: web
-    app.kubernetes.io/part-of: where-for-dinner
+    app.kubernetes.io/part-of: where-for-dinner-availability
     networking.knative.dev/visibility: cluster-local
 spec:
   params:

--- a/where-for-dinner/where-for-dinner-notify/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-notify/config/workload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: where-for-dinner-notify
   labels:
     apps.tanzu.vmware.com/workload-type: web
-    app.kubernetes.io/part-of: where-for-dinner
+    app.kubernetes.io/part-of: where-for-dinner-notify
     networking.knative.dev/visibility: cluster-local
 spec:
   params:

--- a/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: where-for-dinner-search-proc
   labels:
     apps.tanzu.vmware.com/workload-type: web
-    app.kubernetes.io/part-of: where-for-dinner
+    app.kubernetes.io/part-of: where-for-dinner-search-proc
     networking.knative.dev/visibility: cluster-local
 spec:
   params:

--- a/where-for-dinner/where-for-dinner-search/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search/config/workload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: where-for-dinner-search
   labels:
     apps.tanzu.vmware.com/workload-type: web
-    app.kubernetes.io/part-of: where-for-dinner
+    app.kubernetes.io/part-of: where-for-dinner-search
     networking.knative.dev/visibility: cluster-local
 spec:
   params:


### PR DESCRIPTION
Individual app workload configs have the incorrect app.kubernetes.io/part-of label.

Addressing #121 