### PR TITLE
Changed nginx.conf of angular-frontend to not have process-ID 

### DIFF
--- a/angular-frontend/nginx.conf
+++ b/angular-frontend/nginx.conf
@@ -4,8 +4,8 @@ worker_processes 1;
 # Run NGINX in foreground (necessary for containerized NGINX)
 daemon off;
 
-# Set the location of the server's PID file
-pid /tmp/nginx.pid;
+# Do not set the location of the server's PID file as it is already provided by the WebServers Buildpack
+# pid /tmp/nginx.pid;
 
 # Set the location of the server's error log
 error_log stderr;


### PR DESCRIPTION
as part of the configuration, this is already provided by the corresponding Buildpack as startup parameter.