### PR TITLE
Add custom type example to demo-input-types

### DIFF
--- a/demo-input-types/accelerator.yaml
+++ b/demo-input-types/accelerator.yaml
@@ -8,25 +8,21 @@ accelerator:
 
   - name: text
     description: 'Enter some text'
-    display: true
     defaultValue: Text value
 
   - name: toggle
     inputType: checkbox
-    display: true
     dataType: boolean
     defaultValue: true
 
   - name: textarea
     inputType: textarea
-    display: true
     defaultValue: |
       Text line 1
       Text line 2
 
   - name: checkbox
     inputType: checkbox
-    display: true
     dataType: [string]
     defaultValue:
       - value-2
@@ -41,7 +37,6 @@ accelerator:
   - name: checkbox2
     description: 'This option is dependend on - select "choice 3" only to see that option below'
     inputType: checkbox
-    display: true
     dataType: [string]
     defaultValue:
       - value-1
@@ -62,7 +57,6 @@ accelerator:
 
   - name: select
     inputType: select
-    display: true
     defaultValue: value-2
     choices:
       - text: Select choice 1
@@ -74,7 +68,6 @@ accelerator:
 
   - name: radio
     inputType: radio
-    display: true
     defaultValue: value-2
     choices:
       - text: Radio choice 1
@@ -87,7 +80,6 @@ accelerator:
   - name: regexValidation
     label: Regex Validation
     inputType: text
-    display: true
     validationRegex: "^[a-zA-Z]{1,3}$"
 
   - name: required
@@ -96,5 +88,30 @@ accelerator:
     display: true
     required: true
 
+  - name: aSingleTask
+    label: An input using a custom struct type
+    dataType: Task
+
+  - name: severalTasks
+    label: And a dynamic collection of those
+    description: Add and remove as many tasks as you please
+    dataType: [Task]
+    defaultValue: []
+
+  types:
+    - name: Task
+      struct:
+        - name: title
+          dataType: string
+          label: Title
+          description: A sample title
+        - name: details
+          label: Task details
+          description: Enter the task details
+          defaultValue: ""
+        - name: done
+          dataType: boolean
+          label: Done?
+          defaultValue: false
 engine:
   type: YTT

--- a/demo-input-types/results.yaml
+++ b/demo-input-types/results.yaml
@@ -24,3 +24,11 @@ options:
 
   - name: Required
     value: #@ data.values.required
+
+  - name: Single Task
+    value: #@ data.values.aSingleTask
+
+  - name: Several Tasks
+    tasks:
+    #@ for/end t in data.values.severalTasks:
+    - #@ t


### PR DESCRIPTION
Fix https://github.com/pivotal/acc-content/issues/57