### PR TITLE
Remove dependsOn block that refers to not visible options

### DIFF
--- a/fragments/spring-boot-mysql/accelerator.yaml
+++ b/fragments/spring-boot-mysql/accelerator.yaml
@@ -21,9 +21,6 @@ accelerator:
       inputType: text
       defaultValue: "standard"
       description: The storage class to be used for storing MySQL data
-      dependsOn:
-        name: databaseType
-        value: mysql
 
   imports:
     - name: spring-boot-h2

--- a/fragments/spring-boot-postgresql/accelerator.yaml
+++ b/fragments/spring-boot-postgresql/accelerator.yaml
@@ -21,16 +21,10 @@ accelerator:
       inputType: text
       defaultValue: "standard"
       description: The storage class to be used for storing PostgreSQL data
-      dependsOn:
-        name: databaseType
-        value: postgres
     - name: databasePostgresMonitoringClass
       inputType: text
       defaultValue: "standard"
       description: The storage class to be used for monitoring PostgreSQL
-      dependsOn:
-        name: databaseType
-        value: postgres
 
   imports:
     - name: spring-boot-h2


### PR DESCRIPTION
Those blocks referred to option names that are not in the transitive closure of what those fragments "saw" as options. Those were names that could be present in the *importing* accelerators, but this is wrong usage and caused inconsistencies at runtime.