### PR TITLE
add BP_DEBUG_ENABLED env var to tiltfile

### DIFF
--- a/weatherforecast-steeltoe/Tiltfile
+++ b/weatherforecast-steeltoe/Tiltfile
@@ -9,6 +9,7 @@ k8s_custom_deploy(
   apply_cmd="tanzu apps workload apply -f config/workload.yaml --debug --live-update" +
             " --local-path " + LOCAL_PATH +
             " --source-image " + SOURCE_IMAGE +
+            " --build-env BP_DEBUG_ENABLED=true" +
             " --namespace " + NAMESPACE +
             " --yes " +
             OUTPUT_TO_NULL_COMMAND +


### PR DESCRIPTION
- allows workloads applied using this weatherforecast-steeltoe tiltfile to be remotely debugged from Visual Studio by asking the build system to add the VS debug agent ("vsdbg")
  - prevents having to re-apply workloads created via live update before they're able to be remotely debugged; vsdbg should always be present in the container for .NET workloads
- more info on this env var [here](https://paketo.io/docs/howto/dotnet-core/#enable-remote-debugging)

Signed-off-by: Andrew Woosnam <awoosnam@vmware.com>