### PR TITLE
add namespace provisioner examples for gitops

### DIFF
--- a/namespace-provisioner-gitops-examples/LICENSE
+++ b/namespace-provisioner-gitops-examples/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2022 VMware, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/namespace-provisioner-gitops-examples/README.md
+++ b/namespace-provisioner-gitops-examples/README.md
@@ -7,7 +7,7 @@ Namespace provisioner for Tanzu Application Platform provides an easy, secure, a
 
 ## Resources
 
-Here you can find examples for extend and for customize the namespace-provisioner default resources
+Here you can find examples which show how to extend and/or customize the namespace-provisioner default resources.
 
 ### Extend the OOTB default-resources
 
@@ -15,11 +15,11 @@ Platform Operators may need to do additional namespace customization beyond TAP 
 
 #### Custom resources
 
-- Random:  how to add a particular `ConfigMap` using Carvel-YTT *yaml* and *data* modules
-- Scan policies: how to add a `scanpolicy.scanning.apps.tanzu.vmware.com` for *snyk* if the `data.values` contains the key `scanpolicy` and the value is snyk`
-- Tekton pipelines: how to create `pipeline.tekton.dev` for `angular`, `python` or `golang` if the `data.values` contains the key `language` and the value is the desire language
-- Testing scanning supplychain: how to create the `scanpolicy.scanning.apps.tanzu.vmware.com/v1beta1` and the `pipeline.tekton.dev` for java (gradle/maven) projects as referenced in [Install OOTB Supply Chain with Testing and Scanning](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/GUID-getting-started-add-test-and-security.html#install-ootb-supply-chain-with-testing-and-scanning-5)
-- Workload sa: how to create custom `Secret`s, `ServiceAccount`s and `RoleBinding`s
+- [Random](./custom-resources/random/data-values-configmap.yaml):  how to add a particular `ConfigMap` using Carvel-YTT *yaml* and *data* modules
+- [Scan policies](./custom-resources/scanpolicies/snyk-scanpolicies.yaml): how to add a `scanpolicy.scanning.apps.tanzu.vmware.com` for *snyk* if the `data.values` contains the key `scanpolicy` and the value is snyk`
+- [Tekton pipelines](./custom-resources/tekton-pipelines): how to create `pipeline.tekton.dev` for `angular`, `python` or `golang` if the `data.values` contains the key `language` and the value is the desire language
+- [Testing scanning supplychain](./custom-resources/testing-scanning-supplychain/tekton-pipeline-java.yaml): how to create the `scanpolicy.scanning.apps.tanzu.vmware.com/v1beta1` and the `pipeline.tekton.dev` for java (gradle/maven) projects as referenced in [Install OOTB Supply Chain with Testing and Scanning](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/GUID-getting-started-add-test-and-security.html#install-ootb-supply-chain-with-testing-and-scanning-5)
+- [Workload sa](./custom-resources/workload-sa/workload-sa-with-secrets.yaml): how to create custom `Secret`s, `ServiceAccount`s and `RoleBinding`s
 
 
 ### Customize OOTB default-resources
@@ -33,7 +33,7 @@ The Out-Of-The-box *default-resources* can be customized by using GitOps with so
 
 #### Default resources overrides
 
-- Overlays: how to change the `secrets` and `imagePullSecrets` sections of the *default* `ServiceAccount` created by the namespace provisioner
+- [Overlays](./default-resources-overrides/overlays/sa-secrets.lib.yaml): how to change the `secrets` and `imagePullSecrets` sections of the *default* `ServiceAccount` created by the namespace provisioner
 
 ### Control the desired-namespace ConfigMap via GitOps
 
@@ -43,4 +43,4 @@ Users can choose to maintain the *desired-namespaces* `ConfigMap` in their git r
 
 #### Desired-namespaces
 
-How of how the *desired-namespaces* `ConfigMap` can be set via GitOps, it needs to keep unchanged the *name*, the *namespace* and the *annotation* `namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: ""` (This annotation tells the provisioner app to not override this configMap as this is the desired state.)
+- [desired-namespaces](./desired-namespaces/gitops-managed-desired-namespaces.yaml):  How of how the *desired-namespaces* `ConfigMap` can be set via GitOps, it needs to keep unchanged the *name*, the *namespace* and the *annotation* `namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: ""` (This annotation tells the provisioner app to not override this configMap as this is the desired state.)

--- a/namespace-provisioner-gitops-examples/README.md
+++ b/namespace-provisioner-gitops-examples/README.md
@@ -1,0 +1,46 @@
+# Namespace Provisioner Resources
+
+## Namespace provisioner
+
+Namespace provisioner for Tanzu Application Platform provides an easy, secure, automated way for Platform Operators to provision namespaces with the resources and proper namespace-level privileges required for their workloads to function as intended.
+
+
+## Resources
+
+Here you can find examples for extend and for customize the namespace-provisioner default resources
+
+### Extend the OOTB default-resources
+
+Platform Operators may need to do additional namespace customization beyond TAP requirements (such as quota allocation or creation of other namespaced resources) that are not taken care of by the Out of the Box *default-resources* Secret. Platform Operators can add additional git sources in *tap-values* configuration of the namespace provisioner. This allows the Platform Operators to extend the out of the box setup with additional resources which helps them achieve the bespoke customization that they need for their requirement.
+
+#### Custom resources
+
+- Random:  how to add a particular `ConfigMap` using Carvel-YTT *yaml* and *data* modules
+- Scan policies: how to add a `scanpolicy.scanning.apps.tanzu.vmware.com` for *snyk* if the `data.values` contains the key `scanpolicy` and the value is snyk`
+- Tekton pipelines: how to create `pipeline.tekton.dev` for `angular`, `python` or `golang` if the `data.values` contains the key `language` and the value is the desire language
+- Testing scanning supplychain: how to create the `scanpolicy.scanning.apps.tanzu.vmware.com/v1beta1` and the `pipeline.tekton.dev` for java (gradle/maven) projects as referenced in [Install OOTB Supply Chain with Testing and Scanning](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/GUID-getting-started-add-test-and-security.html#install-ootb-supply-chain-with-testing-and-scanning-5)
+- Workload sa: how to create custom `Secret`s, `ServiceAccount`s and `RoleBinding`s
+
+
+### Customize OOTB default-resources
+
+The Out-Of-The-box *default-resources* can be customized by using GitOps with some specific characteristics
+
+- The GitOps customization should be done by using the ytt overlay feature and should be set in the *tap-values* under additional_resources.
+- The additional git resource should be mounted in the *path* `_ytt_lib/customize`, otherwise the customization will not be considered
+- The GitOps repo folder should have a file with an extension `.lib.yaml` to be recognized as a ytt library with members to be exported
+- The library file in the GitOps repo folder should have a function called *customize* with the overlays to be applied to the resources, it can contain 1 or more overlays
+
+#### Default resources overrides
+
+- Overlays: how to change the `secrets` and `imagePullSecrets` sections of the *default* `ServiceAccount` created by the namespace provisioner
+
+### Control the desired-namespace ConfigMap via GitOps
+
+Users can choose to maintain the *desired-namespaces* `ConfigMap` in their git repository and opt not to use the *namespace-provisioner* controller. Users can use their choice of GitOps tool to override the *desired-namespaces* `ConfigMap` in the *tap-namespace-provisioning* namespace.
+
+***NOTE:*** you need to set the *controller* tap value key to “false” (Default is “true”) for namespace provisioner in tap-values.yaml file
+
+#### Desired-namespaces
+
+How of how the *desired-namespaces* `ConfigMap` can be set via GitOps, it needs to keep unchanged the *name*, the *namespace* and the *annotation* `namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: ""` (This annotation tells the provisioner app to not override this configMap as this is the desired state.)

--- a/namespace-provisioner-gitops-examples/custom-resources/random/data-values-configmap.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/random/data-values-configmap.yaml
@@ -1,0 +1,10 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-values-configmap
+type: Opaque
+data:
+  content: #@ yaml.encode(data.values)

--- a/namespace-provisioner-gitops-examples/custom-resources/scanpolicies/snyk-scanpolicies.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/scanpolicies/snyk-scanpolicies.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+#@ if/end hasattr(data.values, "scanpolicy") and data.values.scanpolicy == "snyk":
+---
+apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
+kind: ScanPolicy
+metadata:
+  name: snyk-scan-policy
+  namespace: #@ data.values.name
+  labels:
+    app.kubernetes.io/part-of: component
+spec:
+  regoFile: |
+    package main
+    notAllowedSeverities := ["Critical", "High"]
+    ignoreCves := [""]
+    contains(array, elem) = true {
+      array[_] = elem
+    } else = false { true }
+    isSafe(match) {
+      fails := contains(notAllowedSeverities, match.relationships[_].ratedBy.rating[_].severity)
+      not fails
+    }
+    isSafe(match) {
+      ignore := contains(ignoreCves, match.id)
+      ignore
+    }
+    deny[msg] {
+      vuln := input.vulnerabilities[_]
+      ratings := vuln.relationships[_].ratedBy.rating[_].severity
+      comp := vuln.relationships[_].affect.to[_]
+      not isSafe(vuln)
+      msg = sprintf("%s %s %s", [comp, vuln.id, ratings])
+    }

--- a/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/angular-test.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/angular-test.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+#@ if/end hasattr(data.values, "language") and data.values.language == "angular":
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: developer-defined-tekton-pipeline-angular
+  namespace: #@ data.values.name
+  labels:
+    apps.tanzu.vmware.com/pipeline: test
+    apps.tanzu.vmware.com/language: angular
+spec:
+  params:
+  - name: source-url
+  - name: source-revision
+  tasks:
+  - name: test
+    params:
+    - name: source-url
+      value: $(params.source-url)
+    - name: source-revision
+      value: $(params.source-revision)
+    taskSpec:
+      params:
+      - name: source-url
+      - name: source-revision
+      steps:
+        - name: test
+          image: node:latest
+          script: |-
+            cd `mktemp -d`
+            wget -qO- $(params.source-url) | tar xvz -m
+            ng test

--- a/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/golang-test.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/golang-test.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:data", "data")
+#@ if/end hasattr(data.values, "language") and data.values.language == "golang":
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: developer-defined-tekton-pipeline-golang
+  namespace: #@ data.values.name
+  labels:
+    apps.tanzu.vmware.com/pipeline: test
+    apps.tanzu.vmware.com/language: golang
+spec:
+  params:
+  - name: source-url
+  - name: source-revision
+  tasks:
+  - name: test
+    params:
+    - name: source-url
+      value: $(params.source-url)
+    - name: source-revision
+      value: $(params.source-revision)
+    taskSpec:
+      params:
+      - name: source-url
+      - name: source-revision
+      steps:
+        - name: test
+          image: golang:latest
+          script: |-
+            go test ./... -coverprofile cover.out

--- a/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/python-test.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/tekton-pipelines/python-test.yaml
@@ -1,0 +1,41 @@
+#@ load("@ytt:data", "data")
+#@ if/end hasattr(data.values, "language") and data.values.language == "python":
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: developer-defined-tekton-pipeline-python
+  namespace: #@ data.values.name
+  labels:
+    apps.tanzu.vmware.com/pipeline: "test"
+    apps.tanzu.vmware.com/language: "python"
+spec:
+  params:
+  - name: source-url
+  - name: source-revision
+  workspaces:
+  - name: supplychain-workspace
+  tasks:
+  - name: test
+    params:
+    - name: source-url
+      value: $(params.source-url)
+    - name: source-revision
+      value: $(params.source-revision)
+    workspaces:
+    - name: supplychain-workspace
+      workspace: supplychain-workspace
+    taskSpec:
+      params:
+      - name: source-url
+      - name: source-revision
+      workspaces:
+      - name: supplychain-workspace
+      steps:
+        - name: test
+          image: python:latest
+          script: |-
+            set -ex
+            cd `mktemp -d`
+            wget -qO- $(params.source-url) | tar xvz -m
+            pytest

--- a/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/grype-scan-policy.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/grype-scan-policy.yaml
@@ -1,0 +1,47 @@
+#@ load("@ytt:data", "data")
+#@ def in_list(key, list):
+#@  return hasattr(data.values.tap_values, key) and (data.values.tap_values[key] in list)
+#@ end
+#@ if/end in_list('supply_chain', ['testing_scanning']) and in_list('profile', ['full', 'build']):
+---
+apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
+kind: ScanPolicy
+metadata:
+  name: scan-policy
+  labels:
+    'app.kubernetes.io/part-of': 'scan-system'
+spec:
+  regoFile: |
+    package main
+
+    # Accepted Values: "Critical", "High", "Medium", "Low", "Negligible", "UnknownSeverity"
+    notAllowedSeverities := ["Critical", "High", "UnknownSeverity"]
+    ignoreCves := []
+
+    contains(array, elem) = true {
+      array[_] = elem
+    } else = false { true }
+
+    isSafe(match) {
+      severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+      some i
+      fails := contains(notAllowedSeverities, severities[i])
+      not fails
+    }
+
+    isSafe(match) {
+      ignore := contains(ignoreCves, match.id)
+      ignore
+    }
+
+    deny[msg] {
+      comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+      some i
+      comp := comps[i]
+      vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+      some j
+      vuln := vulns[j]
+      ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
+      not isSafe(vuln)
+      msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
+    }

--- a/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/tekton-pipeline-java.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/tekton-pipeline-java.yaml
@@ -1,0 +1,46 @@
+#@ load("@ytt:data", "data")
+#@ def in_list(key, list):
+#@  return hasattr(data.values.tap_values, key) and (data.values.tap_values[key] in list)
+#@ end
+#@ if/end in_list('supply_chain', ['testing', 'testing_scanning']) and in_list('profile', ['full', 'iterate', 'build']):
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: developer-defined-tekton-pipeline-java
+  labels:
+    apps.tanzu.vmware.com/pipeline: test
+  annotations:
+    kapp.k14s.io/create-strategy: fallback-on-update
+spec:
+  params:
+    - name: source-url
+    - name: source-revision
+  tasks:
+    - name: test
+      params:
+        - name: source-url
+          value: $(params.source-url)
+        - name: source-revision
+          value: $(params.source-revision)
+      taskSpec:
+        params:
+          - name: source-url
+          - name: source-revision
+        steps:
+          - name: test
+            image: gradle
+            script: |-
+              cd `mktemp -d`
+              wget -qO- $(params.source-url) | tar xvz -m
+              pwd
+              MVNW=mvnw
+              GRADLE="build.gradle"
+              if [ -f "$MVNW" ]; then
+                  ./mvnw test
+              elif [ -f "$GRADLE" ]; then
+                  gradle test --debug
+              else
+                  echo "WARNING: No tests were run. This workload is not built with one of the currently supported frameworks (maven or gradle). If using another language/framework, update the image and the script sections of the 'pipeline.tekton.dev/developer-defined-tekton-pipeline' resource in your namespace to match your language/framework."
+                  #exit 1
+              fi

--- a/namespace-provisioner-gitops-examples/custom-resources/workload-sa/workload-sa-with-secrets.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/workload-sa/workload-sa-with-secrets.yaml
@@ -1,0 +1,71 @@
+#@ load("@ytt:base64", "base64")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-workload-token
+  annotations:
+    tekton.dev/git-0: https://git.company.com
+type: kubernetes.io/basic-auth
+stringData:
+  username: gl-secret-user
+  password: gl-secret-pass
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-workload-token
+  annotations:
+    tekton.dev/git-0: https://github.aetna.com
+type: kubernetes.io/basic-auth
+stringData:
+  username: gh-secret-user
+  password: gh-secret-pass
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload-sa
+secrets:
+  - name: registries-credentials
+  - name: cosign
+  - name: gitlab-workload-token
+  - name: github-workload-token
+imagePullSecrets:
+  - name: registries-credentials
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workload-sa-permit-deliverable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deliverable
+subjects:
+  - kind: ServiceAccount
+    name: workload-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workload-sa-permit-workload
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workload
+subjects:
+  - kind: ServiceAccount
+    name: workload-sa
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cosign
+  annotations:
+    kpack.io/cosign.docker-media-types: "1"
+type: Opaque
+data:
+  cosign.key: #@ base64.encode('cosign.key')
+  cosign.password: #@ base64.encode('cosign.password')
+  cosign.pub: #@ base64.encode('cosign.pub')

--- a/namespace-provisioner-gitops-examples/default-resources-overrides/overlays/sa-secrets.lib.yaml
+++ b/namespace-provisioner-gitops-examples/default-resources-overrides/overlays/sa-secrets.lib.yaml
@@ -1,0 +1,15 @@
+#@ load("@ytt:overlay", "overlay")
+#@ def customize():
+
+#! rewrite the default serviceaccount secrets/ requires gitlab-workload-token and github-workload-token secrets from /custom-resources/workload-sa/workload-sa-with-secrets.yaml
+#@overlay/match by=overlay.subset({"apiVersion": "v1", "kind": "ServiceAccount","metadata":{"name":"default"}}), expects="0+"
+---
+secrets:
+  - name: gitlab-workload-token
+  - name: github-workload-token
+  - name: registries-credentials
+imagePullSecrets:
+  - name: gitlab-workload-token
+  - name: github-workload-token
+  - name: registries-credentials
+#@  end

--- a/namespace-provisioner-gitops-examples/desired-namespaces/gitops-managed-desired-namespaces.yaml
+++ b/namespace-provisioner-gitops-examples/desired-namespaces/gitops-managed-desired-namespaces.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: desired-namespaces
+  namespace: tap-namespace-provisioning
+  annotations:
+    kapp.k14s.io/create-strategy: fallback-on-update
+    namespace-provisioner.apps.tanzu.vmware.com/no-overwrite: "" #! This annotation tells the provisioner app to not override this configMap as this is your desired state.
+data:
+  namespaces.yaml: |
+    #@data/values
+    ---
+    namespaces:
+    - name: python-backend-app
+      language: python
+      scanpolicy: snyk
+    - name: angular-fe-app
+      language: angular
+    - name: golang-opts
+      language: golang


### PR DESCRIPTION
Namespace provisioner for Tanzu Application Platform provides an easy, secure, automated way for Platform Operators to provision namespaces with the resources and proper namespace-level privileges required for their workloads to function as intended.

This PR adds the examples meant to be used in the component documentation and for use reference.