### PR TITLE
Add apply_cmd_bat to Tiltfile for Windows

### DIFF
--- a/weatherforecast-steeltoe/Tiltfile
+++ b/weatherforecast-steeltoe/Tiltfile
@@ -14,6 +14,14 @@ k8s_custom_deploy(
             " --yes " +
             OUTPUT_TO_NULL_COMMAND +
             " && kubectl get workload " + NAME + " --namespace " + NAMESPACE + " -o yaml",
+  apply_cmd_bat="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
+            " --local-path " + LOCAL_PATH +
+            " --source-image " + SOURCE_IMAGE +
+            " --build-env BP_DEBUG_ENABLED=true" +
+            " --namespace " + NAMESPACE +          
+            " --yes " +
+            " > NUL " + # windows-compatible "output to null"
+            " && kubectl get workload " + NAME + " --namespace " + NAMESPACE + " -o yaml",
   delete_cmd="tanzu apps workload delete " + NAME + " --namespace " + NAMESPACE + " --yes",
   deps=['./bin'],
   container_selector='workload',

--- a/weatherforecast-steeltoe/Tiltfile
+++ b/weatherforecast-steeltoe/Tiltfile
@@ -2,6 +2,7 @@ SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/steel
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
+OUTPUT_TO_NULL_COMMAND_WINDOWS = os.getenv("OUTPUT_TO_NULL_COMMAND_WINDOWS", default=' > NUL ')
 NAME = "sample-app"
 
 k8s_custom_deploy(
@@ -20,7 +21,7 @@ k8s_custom_deploy(
             " --build-env BP_DEBUG_ENABLED=true" +
             " --namespace " + NAMESPACE +          
             " --yes " +
-            " > NUL " + # windows-compatible "output to null"
+            OUTPUT_TO_NULL_COMMAND_WINDOWS +
             " && kubectl get workload " + NAME + " --namespace " + NAMESPACE + " -o yaml",
   delete_cmd="tanzu apps workload delete " + NAME + " --namespace " + NAMESPACE + " --yes",
   deps=['./bin'],


### PR DESCRIPTION
fixes #149 (thanks @vrabbi for the solution!)

Prevents errors due to default `> /dev/null` on windows by replacing it with windows-compatible `> NUL`

From tilt docs:
> command_bat ( Union [ str , List [ str ]]) – If non-empty and on Windows, takes precedence over command . Ignored on other platforms. If a string, executed as a Windows batch command executed with cmd /S /C ; if a list, will be passed to the operating system as program name and args.