### PR TITLE
Remove javaVersion dependsOn updateBoot3

### DIFF
--- a/java-rest-service/accelerator.yaml
+++ b/java-rest-service/accelerator.yaml
@@ -89,9 +89,6 @@ accelerator:
     - name: javaVersion
       inputType: select
       label: Java version to use
-      dependsOn:
-        name: updateBoot3
-        value: false
       choices:
       - value: "11"
         text: Java 11

--- a/tanzu-java-web-app/accelerator.yaml
+++ b/tanzu-java-web-app/accelerator.yaml
@@ -23,11 +23,6 @@ accelerator:
 
   imports:
   - name: java-version
-    expose:
-    - name: "javaVersion"
-      dependsOn:
-        name: updateBoot3
-        value: false
   - name: tap-workload
   - name: build-wrapper-maven
 


### PR DESCRIPTION
- this avoids the issue where UI still shows a java version that will be overridden in engine processing but the user has no way change it to 17