### PR TITLE
Use compiler-safe(r) namespaces in C# projects

### DIFF
--- a/weatherforecast-csharp/accelerator.yaml
+++ b/weatherforecast-csharp/accelerator.yaml
@@ -18,6 +18,9 @@ accelerator:
     - name: tap-workload
 
 engine:
+  let:
+  - name: compilerSafeAppName
+    expression: '#applicationName.replace("-", "_")'
   merge:
   - include: [ "**" ]
     exclude: [ "README.md", "Sample.csproj", "config/**", "catalog/**" ]
@@ -41,3 +44,9 @@ engine:
         reference: tap-workload
       - include: [ "**" ]
       onConflict: UseFirst
+  - include: [ "**/*.cs" ]
+    chain:
+    - type: ReplaceText
+      substitutions:
+        - text: Sample
+          with: "#compilerSafeAppName"

--- a/weatherforecast-steeltoe/accelerator.yaml
+++ b/weatherforecast-steeltoe/accelerator.yaml
@@ -22,6 +22,9 @@ accelerator:
   - name: tap-workload
 
 engine:
+  let:
+  - name: compilerSafeAppName
+    expression: '#applicationName.replace("-", "_")'
   merge:
   - include: ["**"]
     exclude: ["README.md", "config/**", "catalog/**", "Tiltfile"]
@@ -46,3 +49,10 @@ engine:
         reference: tap-workload
       - include: ["**"]
       onConflict: UseFirst
+  - include: [ "**/*.cs" ]
+    chain:
+    - type: ReplaceText
+      substitutions:
+        - text: Sample
+          with: "#compilerSafeAppName"
+


### PR DESCRIPTION
Adds a quick fix for #179