### PR TITLE
Removing full cluster builder dependency from Where For Dinner UI

### DIFF
--- a/where-for-dinner/doc/TAPDeployment.md
+++ b/where-for-dinner/doc/TAPDeployment.md
@@ -16,7 +16,6 @@ These instructions assume that you have a TAP 1.3.x or greater iterate cluster (
 
 * Tanzu TAP GUI
 * Tanzu Build Services
-* Tanzu Build Services Full Dependencies Package (TAP 1.5 and above.  See NOTE below)
 * Tanzu Cloud Native Runtimes
 * Tanzu Service Bindings
 * Tanzu Services Toolkit
@@ -24,10 +23,6 @@ These instructions assume that you have a TAP 1.3.x or greater iterate cluster (
 * Tanzu Out of the Box Templates
 * Tanzu Source Controller
 * Tanzu AppSSO (required if using the `Enable Security` option).
-
-**NOTE:** Starting with TAP 1.5.0, the Tanzu Build Services Full Dependencies Package is required to properly build the UI service.  This package must be manauly installed
-outside of the standard TAP install procedure.  Instructions for installing this package can be found 
-[here](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/tanzu-build-service-install-tbs.html#install-full-dependencies-6).
 
 ## Quick Start
 

--- a/where-for-dinner/templates/workloads.yaml
+++ b/where-for-dinner/templates/workloads.yaml
@@ -299,8 +299,6 @@ spec:
   - name: annotations
     value: 
       autoscaling.knative.dev/minScale: "1"
-  - name: clusterBuilder
-    value: full
   resources:     
     requests:         
       memory: "500M"


### PR DESCRIPTION
A previous error in the Jammy `base` cluster builder was missing the web server buildpack requiring the UI app to need the `full` clusterbuilder.  This has since been resolved in version 1.10.3 of the tanzu build service package, and the UI app will again build successfully using the `base` cluster builder.