### PR TITLE
+ fix: './mvnw: Permission denied'

### DIFF
--- a/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/tekton-pipeline-java.yaml
+++ b/namespace-provisioner-gitops-examples/custom-resources/testing-scanning-supplychain/tekton-pipeline-java.yaml
@@ -37,6 +37,7 @@ spec:
               MVNW=mvnw
               GRADLE="build.gradle"
               if [ -f "$MVNW" ]; then
+                  chmod +x mvnw
                   ./mvnw test
               elif [ -f "$GRADLE" ]; then
                   gradle test --debug


### PR DESCRIPTION
Added execution permissions for `mvnw`.

Fixed `./mvnw: Permission denied` error thrown while source testing using the `namespace-provisioner` out-of-the-box  `developer-defined-tekton-pipeline-java` tekton pipeline.

```
2023/03/12 12:40:34 Entrypoint initialization
2023/03/12 12:40:35 Decoded script /tekton/scripts/script-0-mgr54
.
.git
.git/HEAD
.git/config
.git/index
.git/objects
.git/objects/info
.git/objects/pack
.git/objects/pack/pack-c3dc5fe5a0514c94d375473cc3d445301ed47ed2.idx
.git/objects/pack/pack-c3dc5fe5a0514c94d375473cc3d445301ed47ed2.pack
.git/refs
.git/refs/heads
.git/refs/heads/master
.git/refs/remotes
.git/refs/remotes/origin
.git/refs/remotes/origin/master
.git/refs/tags
.git/shallow
.mvn
.mvn/wrapper
.mvn/wrapper/maven-wrapper.properties
.tanzuignore
LICENSE
README.md
Tiltfile
accelerator-log.md
catalog
catalog/catalog-info.yaml
config
config/workload.yaml
mvnw
mvnw.cmd
pom.xml
src
src/main
src/main/java
src/main/java/com
src/main/java/com/example
src/main/java/com/example/springboot
src/main/java/com/example/springboot/Application.java
src/main/java/com/example/springboot/HelloController.java
src/main/resources
src/main/resources/application.yml
src/test
src/test/java
src/test/java/com
src/test/java/com/example
src/test/java/com/example/springboot
src/test/java/com/example/springboot/HelloControllerTest.java
/tmp/tmp.O7NfqqA7j2
/tekton/scripts/script-0-mgr54: 9: ./mvnw: Permission denied
```