### PR TITLE
Add AuthServer trust verification for appsso-starter-java

### DIFF
--- a/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/AppSSOAcceleratorApplication.java
+++ b/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/AppSSOAcceleratorApplication.java
@@ -2,8 +2,10 @@ package com.vmware.tanzu.apps.sso.accelerator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
+@EnableWebSecurity
 public class AppSSOAcceleratorApplication {
 
 	public static void main(String[] args) {

--- a/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/config/IssuerTrust.java
+++ b/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/config/IssuerTrust.java
@@ -1,0 +1,52 @@
+package com.vmware.tanzu.apps.sso.accelerator.config;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
+
+/**
+ * IssuerTrust
+ *
+ * Simple class to verify whether the registered clients' issuer is reachable using TLS.
+ * If TLS connection fails, a custom descriptive error message is displayed with instructions
+ * on how to rectify.
+ */
+public class IssuerTrust {
+	private static final Logger logger = LoggerFactory.getLogger(WebSecurityConfig.class);
+
+	private final OAuth2ClientProperties properties;
+
+	public IssuerTrust(OAuth2ClientProperties properties) {
+		this.properties = properties;
+	}
+
+	@PostConstruct
+	void verify() {
+		try {
+			OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties);
+		} catch (IllegalArgumentException e) {
+			if (e.getMessage().contains("Unable to resolve Configuration with the provided Issuer") &&
+					e.getCause().getMessage().contains("unable to find valid certification path to requested target")) {
+				logger.error("\n" + """
+						############################################################
+						Establishing a TLS connection to the AuthServer has failed!
+						
+						The AuthServer may be serving a TLS certificate issued by a
+						certificate authority that is not trusted by this application.
+						Usually, that is the case when the issuing certificate authority
+						is not public.
+						
+						Please refer to AppSSO docs for instructions on how to
+						configure Workloads to trust AuthServers with custom CAs.
+						
+						The application cannot continue loading.
+						############################################################""");
+				System.exit(1);
+			} else {
+				throw e;
+			}
+		}
+	}
+}

--- a/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/config/WebSecurityConfig.java
+++ b/appsso-starter-java/src/main/java/com/vmware/tanzu/apps/sso/accelerator/config/WebSecurityConfig.java
@@ -1,9 +1,13 @@
 package com.vmware.tanzu.apps.sso.accelerator.config;
 
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
@@ -13,16 +17,18 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
-@EnableWebSecurity
+@EnableConfigurationProperties(OAuth2ClientProperties.class)
 public class WebSecurityConfig {
-	private ClientRegistrationRepository clientRegistrationRepository;
 
-	public WebSecurityConfig(ClientRegistrationRepository clientRegistrationRepository) {
-		this.clientRegistrationRepository = clientRegistrationRepository;
+	@Bean(name = "issuerTrust")
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	IssuerTrust issuerTrust(OAuth2ClientProperties properties) {
+		return new IssuerTrust(properties);
 	}
 
 	@Bean
-	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	@DependsOn("issuerTrust")
+	SecurityFilterChain securityFilterChain(HttpSecurity http, ClientRegistrationRepository clientRegistrationRepository) throws Exception {
 		http
 				// Add an authentication check filter to enable auto-redirects if the user is already signed in,
 				// or if the user is attempting to navigate to protected paths.
@@ -35,7 +41,7 @@ public class WebSecurityConfig {
 								.anyRequest().authenticated()
 				)
 				// After a successful logout, redirect to /home.
-				.logout().logoutSuccessHandler(oidcLogoutSuccessHandler()).logoutSuccessUrl("/home")
+				.logout().logoutSuccessHandler(oidcLogoutSuccessHandler(clientRegistrationRepository)).logoutSuccessUrl("/home")
 				.and()
 				.oauth2Login(withDefaults())
 				.oauth2Client(withDefaults());
@@ -43,9 +49,9 @@ public class WebSecurityConfig {
 	}
 
 	// see: https://docs.spring.io/spring-security/reference/servlet/oauth2/login/advanced.html#oauth2login-advanced-oidc-logout
-	private LogoutSuccessHandler oidcLogoutSuccessHandler() {
+	private LogoutSuccessHandler oidcLogoutSuccessHandler(ClientRegistrationRepository clientRegistrationRepository) {
 		OidcClientInitiatedLogoutSuccessHandler oidcLogoutSuccessHandler =
-				new OidcClientInitiatedLogoutSuccessHandler(this.clientRegistrationRepository);
+				new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
 
 		// Sets the location that the End-User's User Agent will be redirected to
 		// after the logout has been performed at the Provider


### PR DESCRIPTION
On launch of `appsso-starter-java` accelerator, an initial connection is established with an AppSSO `AuthServer`. If the connection is over TLS and the AuthServer is serving a certificate issued by a non-public CA, the accelerator fails to launch with a rather cryptic error message. This PR seeks to address the error message issue by capturing the exception and producing a legible error message of what the exact issue is and how to rectify.