### PR TITLE
Add Grype scanning to accelerator samples

### DIFF
--- a/.github/tests/.grype.yaml
+++ b/.github/tests/.grype.yaml
@@ -1,0 +1,6 @@
+ignore:
+  - vulnerability: CVE-2016-1000027 # Serialization of untrusted data is not an intended use case, will not fix
+  - vulnerability: GHSA-mjmj-j48q-9wg2 # This CVE comes from a Spring Boot dependency and the Boot team has determined that the versions we are using is not susceptible to this CVE
+  - vulnerability: CVE-2022-45868 # H2 has stated this is a false positive
+  - vulnerability: GHSA-22wj-vf5f-wrvj # Duplicate of CVE-2022-45868
+  - vulnerability: GHSA-rp65-9cf3-cjxr # This shows up in where-for-dinner-ui because of a dev (non-prod) dependency. Currently, grype doesn't offer a way to ignore dev dependencies.

--- a/.github/tests/angular-frontend-1/scan.sh
+++ b/.github/tests/angular-frontend-1/scan.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/appsso-starter-java-1/scan.sh
+++ b/.github/tests/appsso-starter-java-1/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./gradlew build
+$grype build/libs/appsso-starter-java-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/csharp-rest-service-1/scan.sh
+++ b/.github/tests/csharp-rest-service-1/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+dotnet build
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/generate.sh
+++ b/.github/tests/generate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir /tmp/result
+
+[[ $1 =~ (.*)-.* ]]
+accname=${BASH_REMATCH[1]}
+
+pushd ${GITHUB_WORKSPACE}
+
+.github/tests/tanzu-accelerator-linux_amd64 generate-from-local \
+  --server-url http://localhost:8888 \
+  --output-dir /tmp/result \
+  --fragment-paths                       app-sso-client=fragments/app-sso-client \
+  --fragment-paths                         java-version=fragments/java-version \
+  --fragment-paths                          live-update=fragments/live-update \
+  --fragment-paths                         java-version=fragments/java-version \
+  --fragment-paths   spring-boot-app-sso-auth-code-flow=fragments/spring-boot-app-sso-auth-code-flow \
+  --fragment-paths                 spring-boot-database=fragments/spring-boot-database \
+  --fragment-paths                       spring-boot-h2=fragments/spring-boot-h2 \
+  --fragment-paths                    spring-boot-mysql=fragments/spring-boot-mysql \
+  --fragment-paths               spring-boot-postgresql=fragments/spring-boot-postgresql \
+  --fragment-paths                  steeltoe-postgresql=fragments/steeltoe-postgresql \
+  --fragment-paths                 testcontainers-mysql=fragments/testcontainers-mysql \
+  --fragment-paths            testcontainers-postgresql=fragments/testcontainers-postgresql \
+  --fragment-paths                       tap-initialize=fragments/tap-initialize \
+  --fragment-paths                         tap-workload=fragments/tap-workload \
+  --fragment-paths                  build-wrapper-maven=fragments/build-wrapper-maven \
+  --fragment-paths                 build-wrapper-gradle=fragments/build-wrapper-gradle \
+  --accelerator-path ${accname}=${accname} \
+  $([ -f .github/tests/$1/options.json ] && echo --options-file .github/tests/$1/options.json)
+
+popd

--- a/.github/tests/java-rest-service-boot3/scan.sh
+++ b/.github/tests/java-rest-service-boot3/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-gradle+flyway+mysql/scan.sh
+++ b/.github/tests/java-rest-service-gradle+flyway+mysql/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./gradlew build
+$grype build/libs/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-gradle+liquibase+h2/scan.sh
+++ b/.github/tests/java-rest-service-gradle+liquibase+h2/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./gradlew build
+$grype build/libs/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-gradle+liquibase+postgres/scan.sh
+++ b/.github/tests/java-rest-service-gradle+liquibase+postgres/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./gradlew build
+$grype build/libs/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-maven+flyway+h2/scan.sh
+++ b/.github/tests/java-rest-service-maven+flyway+h2/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-maven+flyway+postgres/scan.sh
+++ b/.github/tests/java-rest-service-maven+flyway+postgres/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-rest-service-maven+liquibase+mysql/scan.sh
+++ b/.github/tests/java-rest-service-maven+liquibase+mysql/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/customer-profile-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-server-side-ui-gradle+sso/scan.sh
+++ b/.github/tests/java-server-side-ui-gradle+sso/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./gradlew build
+$grype build/libs/server-side-ui-starter-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/java-server-side-ui-maven+nosso/scan.sh
+++ b/.github/tests/java-server-side-ui-maven+nosso/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/server-side-ui-starter-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/node-express-1/scan.sh
+++ b/.github/tests/node-express-1/scan.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/react-frontend-1/scan.sh
+++ b/.github/tests/react-frontend-1/scan.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/scan.sh
+++ b/.github/tests/scan.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 [[ $1 =~ (.*)-.* ]]
+grype_location=$2
 
 pushd ${GITHUB_WORKSPACE}/.github/tests/$1
 
-[ -f assertions.sh ] && ./assertions.sh /tmp/result
+[ -f scan.sh ] && ./scan.sh /tmp/result $grype_location
 
 popd

--- a/.github/tests/spring-cloud-serverless-1/scan.sh
+++ b/.github/tests/spring-cloud-serverless-1/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/spring-cloud-serverless-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/spring-smtp-gateway-1/scan.sh
+++ b/.github/tests/spring-smtp-gateway-1/scan.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype smtp-gateway/target/smtp-gateway-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+$grype smtp-sink/target/smtp-sink-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/tanzu-java-web-app-boot2/scan.sh
+++ b/.github/tests/tanzu-java-web-app-boot2/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/demo-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/tanzu-java-web-app-boot3/scan.sh
+++ b/.github/tests/tanzu-java-web-app-boot3/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+$grype target/demo-0.0.1-SNAPSHOT.jar --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/weatherforecast-csharp-1/scan.sh
+++ b/.github/tests/weatherforecast-csharp-1/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+dotnet build
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/weatherforecast-steeltoe-1/scan.sh
+++ b/.github/tests/weatherforecast-steeltoe-1/scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+dotnet build
+$grype dir:. --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+
+popd

--- a/.github/tests/where-for-dinner-1/scan.sh
+++ b/.github/tests/where-for-dinner-1/scan.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+pushd $1
+grype=$2
+
+./mvnw package
+
+$grype where-for-dinner-ui --fail-on high --config ${GITHUB_WORKSPACE}/.github/tests/.grype.yaml
+echo "TODO: Scan Java services when the following Grype issue (which produces many false positives) is resolved https://github.com/anchore/grype/issues/1009"
+
+popd


### PR DESCRIPTION
Closes https://github.com/pivotal/acc-release/issues/490

note: The samples csharp-rest-service and weatherforecast-steeltoe fail the vulnerability scan. We could use help from someone with C# expertise to help resolve them.