### PR TITLE
updates Namespace Provisioner samples of polyglot testing pipelines for TAP 1.5 

### DIFF
--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-golang.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-golang.yaml
@@ -10,7 +10,6 @@ kind: Pipeline
 metadata:
   name: tekton-pipeline-golang
   labels:
-    apps.tanzu.vmware.com/pipeline: test
     apps.tanzu.vmware.com/language: golang
   annotations:
     kapp.k14s.io/create-strategy: fallback-on-update

--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-java.yaml
@@ -10,7 +10,6 @@ kind: Pipeline
 metadata:
   name: tekton-pipeline-java
   labels:
-    apps.tanzu.vmware.com/pipeline: test
     apps.tanzu.vmware.com/language: java
   annotations:
     kapp.k14s.io/create-strategy: fallback-on-update

--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-nodejs.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-nodejs.yaml
@@ -10,7 +10,6 @@ kind: Pipeline
 metadata:
   name: tekton-pipeline-nodejs
   labels:
-    apps.tanzu.vmware.com/pipeline: test
     apps.tanzu.vmware.com/language: nodejs
   annotations:
     kapp.k14s.io/create-strategy: fallback-on-update


### PR DESCRIPTION
Namespace provisioner for Tanzu Application Platform provides an easy, secure, automated way for Platform Operators to provision namespaces with the resources and proper namespace-level privileges required for their workloads to function as intended.

This PR updates an examples meant to be used in the component documentation and for use reference.