### PR TITLE
Feat/remove source image

### DIFF
--- a/.github/tests/java-rest-service-boot3/options.json
+++ b/.github/tests/java-rest-service-boot3/options.json
@@ -11,6 +11,5 @@
     "exposeOpenAPIEndpoint": false,
     "javaVersion": "17",
     "databaseIntegrationTestType": "testcontainers",
-    "liveUpdateIDESupport": true,
-    "sourceRepositoryPrefix": "dev.local"
+    "liveUpdateIDESupport": true
 }

--- a/.github/tests/java-rest-service-maven+flyway+h2/options.json
+++ b/.github/tests/java-rest-service-maven+flyway+h2/options.json
@@ -11,6 +11,5 @@
   "exposeOpenAPIEndpoint": false,
   "javaVersion": "11",
   "databaseIntegrationTestType":  "in-memory",
-  "liveUpdateIDESupport": true,
-  "sourceRepositoryPrefix": "dev.local"
+  "liveUpdateIDESupport": true
 }

--- a/.github/tests/java-rest-service-maven+flyway+postgres/options.json
+++ b/.github/tests/java-rest-service-maven+flyway+postgres/options.json
@@ -11,6 +11,5 @@
   "exposeOpenAPIEndpoint": false,
   "javaVersion": "11",
   "databaseIntegrationTestType":  "testcontainers",
-  "liveUpdateIDESupport": true,
-  "sourceRepositoryPrefix": "dev.local"
+  "liveUpdateIDESupport": true
 }

--- a/.github/tests/java-rest-service-maven+liquibase+mysql/options.json
+++ b/.github/tests/java-rest-service-maven+liquibase+mysql/options.json
@@ -11,6 +11,5 @@
   "exposeOpenAPIEndpoint": false,
   "javaVersion": "11",
   "databaseIntegrationTestType":  "testcontainers",
-  "liveUpdateIDESupport": true,
-  "sourceRepositoryPrefix": "dev.local"
+  "liveUpdateIDESupport": true
 }

--- a/.github/tests/java-server-side-ui-maven+nosso/options.json
+++ b/.github/tests/java-server-side-ui-maven+nosso/options.json
@@ -6,6 +6,5 @@
   "groupId": "com.example",
   "packageName": "com.example.serversideuistarter",
   "javaVersion": "11",
-  "liveUpdateIDESupport": true,
-  "sourceRepositoryPrefix": "dev.local"
+  "liveUpdateIDESupport": true
 }

--- a/.github/tests/spring-cloud-serverless-1/options.json
+++ b/.github/tests/spring-cloud-serverless-1/options.json
@@ -1,5 +1,4 @@
 {
   "deploymentType": "workload",
-  "sourceRepositoryPrefix": "dev.local",
   "javaVersion": "11"
 }

--- a/.github/tests/tap-initialize-1/options.json
+++ b/.github/tests/tap-initialize-1/options.json
@@ -1,6 +1,5 @@
 {
   "targetProject": "target-project",
   "includeHasTests": false,
-  "liveUpdateIDESupport": true,
-  "sourceRepositoryPrefix": "dev.local"
+  "liveUpdateIDESupport": true
 }

--- a/angular-frontend/README.md
+++ b/angular-frontend/README.md
@@ -76,14 +76,13 @@ Using the Tanzu CLI you could apply the workload using the local sources:
 ```bash
 tanzu apps workload apply \
   --file config/workload.yaml \
-  --namespace <namespace> --source-image <image-registry> \
+  --namespace <namespace> \
   --local-path . \
   --yes \
   --tail
 ````
 
-Note: change the namespace to where you would like to deploy this workload. Also define the (private) image registry you
-are allowed to push the source-image, like: `docker.io/username/repository`.
+Note: change the namespace to where you would like to deploy this workload.
 
 --- StartAuthorization
 ### Authorization

--- a/csharp-rest-service/README.md
+++ b/csharp-rest-service/README.md
@@ -31,7 +31,7 @@ tanzu apps workload apply -f config/workload.yaml
 Deploy your app from your local working directory by running:
 
 ```script
-tanzu apps workload create csharp-rest-service -f config/workload.yaml --local-path . --source-image <REPOSITORY-PREFIX>/csharp-rest-service-source --type web
+tanzu apps workload create csharp-rest-service -f config/workload.yaml --local-path . csharp-rest-service-source --type web
 ```
 
 ## Accessing the app deployed to your cluster
@@ -54,10 +54,7 @@ You will have to update some fields in the root directory's `Tiltfile` to connec
 
 Update the `allow_k8s_contexts` line of the `Tiltfile` to indicate the Kubernetes context to use.
 
-Update the `Tiltfile` or set the SOURCE_IMAGE environment variable to indicate the registry path where TAP should store your image.
-
 ```script
-export SOURCE_IMAGE=registry/project/csharp-rest-service
 export K8S_TEST_CONTEXT="a-kubernetes-context"
 tilt up
 tilt down

--- a/csharp-rest-service/README.md
+++ b/csharp-rest-service/README.md
@@ -31,7 +31,7 @@ tanzu apps workload apply -f config/workload.yaml
 Deploy your app from your local working directory by running:
 
 ```script
-tanzu apps workload create csharp-rest-service -f config/workload.yaml --local-path . csharp-rest-service-source --type web
+tanzu apps workload create csharp-rest-service -f config/workload.yaml --local-path . --type web
 ```
 
 ## Accessing the app deployed to your cluster

--- a/csharp-rest-service/Tiltfile
+++ b/csharp-rest-service/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/csharp-rest-service-source') # update registry
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 NAME = "csharp-rest-service"
@@ -7,7 +6,6 @@ k8s_custom_deploy(
   NAME,
   apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
             " --local-path " + LOCAL_PATH +
-            " --source-image " + SOURCE_IMAGE +
             " --namespace " + NAMESPACE +
             " --build-env BP_DEBUG_ENABLED=true" +
             " --yes " +

--- a/fragments/live-update/DEPLOYING.md
+++ b/fragments/live-update/DEPLOYING.md
@@ -8,8 +8,6 @@ Follow [instructions in the documentation](https://docs.vmware.com/en/Tanzu-Appl
 
 These are the basic steps to use live update:
 
-1. In Visual Studio Code, navigate to `Preferences > Settings > Extensions > Tanzu`.
-    - In the `Source Image` field, provide the destination image repository to publish an image containing your workload source code. This should match what is specified for `SOURCE_IMAGE` default in the Tiltfile.
 1. From the Command Palette (⇧⌘P), type "Tanzu", and select `Tanzu: Live Update Start`. You can view output from Tanzu Application Platform and from Tilt indicating that the container is being built and deployed.
     - You see "Live Update starting..." in the status bar at the bottom right.
     - Live update can take 1-3 minutes while the workload deploys and the Knative service becomes available.
@@ -40,7 +38,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create my-project -f config/workload.yaml \
   --local-path . \
-  --source-image dev.local/my-project-source \
   --type web
 ```
 

--- a/fragments/live-update/Tiltfile
+++ b/fragments/live-update/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='dev.local/my-project-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'my-project',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
               " --local-path " + LOCAL_PATH +
-              " --source-image " + SOURCE_IMAGE +
               " --namespace " + NAMESPACE +
               " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/fragments/live-update/accelerator.yaml
+++ b/fragments/live-update/accelerator.yaml
@@ -8,14 +8,6 @@ accelerator:
       dataType: boolean
       defaultValue: true
 
-    - name: sourceRepositoryPrefix
-      inputType: text
-      label: The source image repository prefix to use when pushing the source
-      description: The prefix for the source image repository where source can be stored during development
-      defaultValue: dev.local
-      dependsOn:
-        name: liveUpdateIDESupport
-
 engine:
   merge:
     - condition: "#liveUpdateIDESupport"
@@ -25,10 +17,6 @@ engine:
           substitutions:
             - text: my-project
               with: "#artifactId"
-        - type: ReplaceText
-          substitutions:
-            - text: dev.local
-              with: "#sourceRepositoryPrefix"
     - condition: "#liveUpdateIDESupport"
       include: ["DEPLOYING.md"]
       chain:
@@ -36,7 +24,3 @@ engine:
           substitutions:
             - text: my-project
               with: "#artifactId"
-        - type: ReplaceText
-          substitutions:
-            - text: dev.local
-              with: "#sourceRepositoryPrefix"

--- a/fragments/tap-initialize/DEPLOYING.md
+++ b/fragments/tap-initialize/DEPLOYING.md
@@ -17,7 +17,6 @@ If you would like to deploy the code from your local working directory you can u
 ```
 tanzu apps workload create my-project -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/my-project-source \
   --type web
 ```
 

--- a/java-function/DEPLOYING.md
+++ b/java-function/DEPLOYING.md
@@ -92,7 +92,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create java-function -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/java-function-source \
   --type web
 ```
 
@@ -152,10 +151,7 @@ You will have to update some fields in the root directory's `Tiltfile` to connec
 
 Update the `allow_k8s_contexts` line of the `Tiltfile` to indicate the Kubernetes context to use. 
 
-Update the `Tiltfile` or set the SOURCE_IMAGE environment variable to indicate the registry path where TAP should store your image. 
-
 ```
-export SOURCE_IMAGE=registry/project/java-function
 export K8S_TEST_CONTEXT="a-kubernetes-context"
 tilt up
 tilt down

--- a/java-function/Tiltfile
+++ b/java-function/Tiltfile
@@ -1,5 +1,4 @@
 # You will need to modify this file to enable Tilt live debugging
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='source-image-location') # CHANGEME - replace `source-image-location` with your writable repository
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -9,7 +8,6 @@ k8s_custom_deploy(
     'java-function',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/java-rest-service/README.md
+++ b/java-rest-service/README.md
@@ -164,14 +164,12 @@ Using the Tanzu CLI one could apply the workload using the local sources:
 tanzu apps workload apply \
   --file config/workload.yaml \
   --namespace <workload-namespace> \
-  --source-image <image-registry> \
   --local-path . \
   --yes \
   --tail
 ```
 
-Note: change the namespace to where you would like to deploy this workload. Also define the (private) image registry you
-are allowed to push the source-image, like: `docker.io/username/repository`.
+Note: change the namespace to where you would like to deploy this workload.
 
 ### Visual Studio Code Tanzu Plugin
 

--- a/java-server-side-ui/README.md
+++ b/java-server-side-ui/README.md
@@ -81,14 +81,13 @@ Using the Tanzu CLI one could apply the workload using the local sources:
 ```bash
 tanzu apps workload apply \
   --file config/workload.yaml \
-  --namespace <namespace> --source-image <image-registry> \
+  --namespace <namespace> \
   --local-path . \
   --yes \
   --tail
 ````
 
-> Change the namespace to where you would like to deploy this workload. Also define the (private) image registry you
-are allowed to push the source-image, like: `docker.io/username/repository`.
+> Change the namespace to where you would like to deploy this workload.
 
 ### Visual Studio Code Tanzu Plugin
 When developing locally but would like to deploy the local code to the cluster, the Tanzu Plugin could help.

--- a/node-express/DEPLOYING.md
+++ b/node-express/DEPLOYING.md
@@ -15,7 +15,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create node-express -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/node-express-source \
   --type web
 ```
 

--- a/node-function/DEPLOYING.md
+++ b/node-function/DEPLOYING.md
@@ -67,7 +67,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create node-function -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/node-function-source \
   --type web
 ```
 
@@ -91,10 +90,7 @@ You may use [tilt](https://github.com/tilt-dev/tilt) `>v0.27.2` in combination w
 
 Update the `allow_k8s_contexts` line of the `Tiltfile` to indicate the Kubernetes context to use. 
 
-Update the `Tiltfile` or set the SOURCE_IMAGE environment variable to indicate the registry path where TAP should store your image. 
-
 ```
-export SOURCE_IMAGE=registry/project/node-function
 export K8S_TEST_CONTEXT="a-kubernetes-context"
 tilt up
 tilt down

--- a/node-function/Tiltfile
+++ b/node-function/Tiltfile
@@ -1,5 +1,4 @@
 # You will need to modify this file to enable Tilt live debugging
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='source-image-location') # CHANGEME - replace `source-image-location` with your writable repository
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 K8S_TEST_CONTEXT = os.getenv("K8S_TEST_CONTEXT", default='')
@@ -10,7 +9,6 @@ k8s_custom_deploy(
     'node-function',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/node-function/test.sh
+++ b/node-function/test.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-# Prerequisites: set these two environment variables for the Tiltfile
-#SOURCE_IMAGE
+# Prerequisites: set environment variable(s) for the Tiltfile
 #K8S_TEST_CONTEXT
 
 # Delete the previous run

--- a/python-function/DEPLOYING.md
+++ b/python-function/DEPLOYING.md
@@ -76,7 +76,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create python-function -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/python-function-source \
   --type web
 ```
 

--- a/python-web-app/Tiltfile
+++ b/python-web-app/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='dev.local/python-web-app-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
@@ -7,7 +6,6 @@ k8s_custom_deploy(
     'python-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
-               " --source-image " + SOURCE_IMAGE +
                " --namespace " + NAMESPACE +
                " --yes " +
                OUTPUT_TO_NULL_COMMAND +

--- a/react-frontend/README.md
+++ b/react-frontend/README.md
@@ -82,14 +82,13 @@ Using the Tanzu CLI one could apply the workload using the local sources:
 ```bash
 tanzu apps workload apply \
   --file config/workload.yaml \
-  --namespace <namespace> --source-image <image-registry> \
+  --namespace <namespace> \
   --local-path . \
   --yes \
   --tail
 ````
 
-Note: change the namespace to where you would like to deploy this workload. Also define the (private) image registry you
-are allowed to push the source-image, like: `docker.io/username/repository`.
+Note: change the namespace to where you would like to deploy this workload.
 
 ### Visual Studio Code Tanzu Plugin
 When developing local but would like to deploy the local code to the cluster the Tanzu Plugin could help.

--- a/spring-cloud-serverless/kubernetes/tap/DEPLOYING.md
+++ b/spring-cloud-serverless/kubernetes/tap/DEPLOYING.md
@@ -8,8 +8,6 @@ Follow [instructions in the documentation](https://docs.vmware.com/en/Tanzu-Appl
 
 These are the basic steps to use live update:
 
-1. In Visual Studio Code, navigate to `Preferences > Settings > Extensions > Tanzu`.
-    - In the `Source Image` field, provide the destination image repository to publish an image containing your workload source code. This should match what is specified for `SOURCE_IMAGE` default in the Tiltfile.
 1. From the Command Palette (⇧⌘P), type "Tanzu", and select `Tanzu: Live Update Start`. You can view output from Tanzu Application Platform and from Tilt indicating that the container is being built and deployed.
     - You see "Live Update starting..." in the status bar at the bottom right.
     - Live update can take 1-3 minutes while the workload deploys and the Knative service becomes available.
@@ -40,7 +38,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create hello-fun -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/hello-fun-source \
   --type web
 ```
 

--- a/spring-cloud-serverless/kubernetes/tap/Tiltfile
+++ b/spring-cloud-serverless/kubernetes/tap/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='dev.local/hello-fun-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'hello-fun',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
               " --local-path " + LOCAL_PATH +
-              " --source-image " + SOURCE_IMAGE +
               " --namespace " + NAMESPACE +
               " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/spring-smtp-gateway/smtp-gateway/Tiltfile
+++ b/spring-smtp-gateway/smtp-gateway/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/smtp-gateway-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'spring-smtp-gateway',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/spring-smtp-gateway/smtp-sink/Tiltfile
+++ b/spring-smtp-gateway/smtp-sink/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/smtp-sink-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'smtp-sink',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/tanzu-java-web-app/Tiltfile
+++ b/tanzu-java-web-app/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/tanzu-java-web-app-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
-               " --source-image " + SOURCE_IMAGE +
                " --namespace " + NAMESPACE +
                " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/tanzu-java-web-app/Tiltfile_gradle_intellij
+++ b/tanzu-java-web-app/Tiltfile_gradle_intellij
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/tanzu-java-web-app-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
-               " --source-image " + SOURCE_IMAGE +
                " --namespace " + NAMESPACE +
                " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/tanzu-java-web-app/Tiltfile_gradle_vscode
+++ b/tanzu-java-web-app/Tiltfile_gradle_vscode
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/tanzu-java-web-app-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
-               " --source-image " + SOURCE_IMAGE +
                " --namespace " + NAMESPACE +
                " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",

--- a/weatherforecast-csharp/README.md
+++ b/weatherforecast-csharp/README.md
@@ -34,7 +34,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create sample-app -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/sample-app-source \
   --type web
 ```
 

--- a/weatherforecast-steeltoe/README.md
+++ b/weatherforecast-steeltoe/README.md
@@ -37,7 +37,6 @@ If you would like deploy the code from your local working directory you can use 
 ```
 tanzu apps workload create sample-app -f config/workload.yaml \
   --local-path . \
-  --source-image <REPOSITORY-PREFIX>/sample-app-source \
   --type web
 ```
 

--- a/weatherforecast-steeltoe/Tiltfile
+++ b/weatherforecast-steeltoe/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/steeltoe-weatherforecast-source') # update registry
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 NAME = "sample-app"
@@ -7,7 +6,6 @@ k8s_custom_deploy(
   NAME,
   apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
             " --local-path " + LOCAL_PATH +
-            " --source-image " + SOURCE_IMAGE +
             " --build-env BP_DEBUG_ENABLED=true" +
             " --namespace " + NAMESPACE +
             " --yes " +

--- a/where-for-dinner/where-for-dinner-api-gateway/Tiltfile
+++ b/where-for-dinner/where-for-dinner-api-gateway/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/where-for-dinner-api-gateway-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'where-for-dinner',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/where-for-dinner/where-for-dinner-availability/Tiltfile
+++ b/where-for-dinner/where-for-dinner-availability/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/where-for-dinner-availability-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'where-for-dinner-availability',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/where-for-dinner/where-for-dinner-crawler-python/Tiltfile
+++ b/where-for-dinner/where-for-dinner-crawler-python/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='dev.local/where-for-dinner-crawler-python-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
@@ -7,7 +6,6 @@ k8s_custom_deploy(
     'where-for-dinner-crawler',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
-               " --source-image " + SOURCE_IMAGE +
                " --namespace " + NAMESPACE +
                " --yes " +
                OUTPUT_TO_NULL_COMMAND +

--- a/where-for-dinner/where-for-dinner-notify/Tiltfile
+++ b/where-for-dinner/where-for-dinner-notify/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/where-for-dinner-notify-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'where-for-dinner-notify',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/where-for-dinner/where-for-dinner-search-proc/Tiltfile
+++ b/where-for-dinner/where-for-dinner-search-proc/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/where-for-dinner-search-proc-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'where-for-dinner-search-proc',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,

--- a/where-for-dinner/where-for-dinner-search/Tiltfile
+++ b/where-for-dinner/where-for-dinner-search/Tiltfile
@@ -1,4 +1,3 @@
-SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/where-for-dinner-search-source')
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
 
@@ -6,7 +5,6 @@ k8s_custom_deploy(
     'where-for-dinner-search',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
-        " --source-image " + SOURCE_IMAGE +
         " --namespace " + NAMESPACE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,


### PR DESCRIPTION
With Local Source Proxy support, users should not have to specify the --source-image flag anymore.

If users want to bypass Local Source Proxy, they will have to update their Tiltfile manually 

We expect clusters to enable Local Source Proxy support by default, and that specifying source-image will be an edge case