### PR TITLE
Supporting TLS Redis connection and fixing Pollable bean.

### DIFF
--- a/where-for-dinner/where-for-dinner-availability/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-availability/config/workload.yaml
@@ -28,8 +28,8 @@ spec:
   - name: rmq
     ref:
       apiVersion: services.apps.tanzu.vmware.com/v1alpha1
-      kind: ResourceClaim
-      name: rmq-where-for-dinner
+      kind: ClassClaim
+      name: msgbroker-where-for-dinner
   source:
     git:
       url: <https URL for your generated project's Git repository>

--- a/where-for-dinner/where-for-dinner-notify/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-notify/config/workload.yaml
@@ -28,8 +28,8 @@ spec:
   - name: rmq
     ref:
       apiVersion: services.apps.tanzu.vmware.com/v1alpha1
-      kind: ResourceClaim
-      name: rmq-where-for-dinner
+      kind: ClassClaim
+      name: msgbroker-where-for-dinner
   source:
     git:
       url: <https URL for your generated project's Git repository>

--- a/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search-proc/config/workload.yaml
@@ -28,8 +28,8 @@ spec:
   - name: rmq
     ref:
       apiVersion: services.apps.tanzu.vmware.com/v1alpha1
-      kind: ResourceClaim
-      name: rmq-where-for-dinner
+      kind: ClassClaim
+      name: msgbroker-where-for-dinner
   source:
     git:
       url: <https URL for your generated project's Git repository>

--- a/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
+++ b/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
@@ -119,12 +119,16 @@ where-for-dinner:
 spring:
   config.activate.on-profile: redis
 
+  redis:
+    ssl: false
+
   data:
     redis:
       # Workaround for https://github.com/spring-cloud/spring-cloud-bindings/issues/87:
       host: ${spring.redis.host}
       password: ${spring.redis.password}
       port: ${spring.redis.port}
+      ssl: ${spring.redis.ssl}
   
 management:
   health:

--- a/where-for-dinner/where-for-dinner-search/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-search/config/workload.yaml
@@ -38,7 +38,7 @@ spec:
     ref:
       apiVersion: services.apps.tanzu.vmware.com/v1alpha1
       kind: ClassClaim
-      name: msgbroker-where-for-dinner   
+      name: msgbroker-where-for-dinner
   source:
     git:
       url: <https URL for your generated project's Git repository>

--- a/where-for-dinner/where-for-dinner-search/src/main/resources/application.yml
+++ b/where-for-dinner/where-for-dinner-search/src/main/resources/application.yml
@@ -19,12 +19,12 @@ spring:
   sql.init.platform: h2
 
   cloud: 
+    function:
+      definition: submittedSearches    
     stream:
       defaultBinder: rabbit
       poller:
         fixed-delay: ${where-for-dinner.searchEvent.period} 
-      function:
-        definition: submittedSearches
       bindings: 
         submittedSearches-out-0: 
           destination: where-for-dinner-search-criteria


### PR DESCRIPTION
Also aligning service claimss for RabbitMQ in individual workload.yaml files to use `ClassClaim` instead of `ResourceClaim` to match the config in app-operator directory (which uses `ClassClaim`)

Addressing issues #263 and #262.