### PR TITLE
updates nsp sample git secret to reference password instead of token

### DIFF
--- a/ns-provisioner-samples/credentials/git.yaml
+++ b/ns-provisioner-samples/credentials/git.yaml
@@ -9,4 +9,4 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: #@ data.values.imported.git.username
-  password: #@ data.values.imported.git.token
+  password: #@ data.values.imported.git.password


### PR DESCRIPTION
Namespace provisioner for Tanzu Application Platform provides an easy, secure, automated way for Platform Operators to provision namespaces with the resources and proper namespace-level privileges required for their workloads to function as intended.

This PR updates an example used in the component documentation to use `password` from `data.values.imported` instead of token.