### PR TITLE
feat: add --wait-timeout and --type flags to Tiltfiles

### DIFF
--- a/csharp-rest-service/Tiltfile
+++ b/csharp-rest-service/Tiltfile
@@ -1,5 +1,7 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 NAME = "csharp-rest-service"
 
 k8s_custom_deploy(
@@ -7,6 +9,8 @@ k8s_custom_deploy(
   apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
             " --local-path " + LOCAL_PATH +
             " --namespace " + NAMESPACE +
+            " --wait-timeout " + WAIT_TIMEOUT +
+            " --type " + TYPE +
             " --build-env BP_DEBUG_ENABLED=true" +
             " --yes " +
             " -oyaml",

--- a/fragments/live-update/Tiltfile
+++ b/fragments/live-update/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'my-project',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
               " --local-path " + LOCAL_PATH +
               " --namespace " + NAMESPACE +
+              " --wait-timeout " + WAIT_TIMEOUT +
+              " --type " + TYPE +
               " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     deps=['pom.xml', './target/classes'],

--- a/java-function/Tiltfile
+++ b/java-function/Tiltfile
@@ -1,6 +1,8 @@
 # You will need to modify this file to enable Tilt live debugging
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 allow_k8s_contexts('your-k8s-context') # CHANGEME - replace `your-k8s-context` with your targeted Kubernetes context
 
@@ -9,6 +11,8 @@ k8s_custom_deploy(
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/node-function/Tiltfile
+++ b/node-function/Tiltfile
@@ -1,6 +1,8 @@
 # You will need to modify this file to enable Tilt live debugging
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 K8S_TEST_CONTEXT = os.getenv("K8S_TEST_CONTEXT", default='')
 
 allow_k8s_contexts(K8S_TEST_CONTEXT)
@@ -10,6 +12,8 @@ k8s_custom_deploy(
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['.'],

--- a/python-web-app/Tiltfile
+++ b/python-web-app/Tiltfile
@@ -1,5 +1,7 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
 
 k8s_custom_deploy(
@@ -7,6 +9,8 @@ k8s_custom_deploy(
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
                " --namespace " + NAMESPACE +
+               " --wait-timeout " + WAIT_TIMEOUT +
+               " --type " + TYPE +
                " --yes " +
                OUTPUT_TO_NULL_COMMAND +
                " && kubectl get workload python-web-app --namespace " + NAMESPACE + " -o yaml",

--- a/spring-cloud-serverless/kubernetes/tap/Tiltfile
+++ b/spring-cloud-serverless/kubernetes/tap/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'hello-fun',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
               " --local-path " + LOCAL_PATH +
               " --namespace " + NAMESPACE +
+              " --wait-timeout " + WAIT_TIMEOUT +
+              " --type " + TYPE +
               " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     deps=['pom.xml', './target/classes'],

--- a/spring-smtp-gateway/smtp-gateway/Tiltfile
+++ b/spring-smtp-gateway/smtp-gateway/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'spring-smtp-gateway',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/spring-smtp-gateway/smtp-sink/Tiltfile
+++ b/spring-smtp-gateway/smtp-sink/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'smtp-sink',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/tanzu-java-web-app/Tiltfile
+++ b/tanzu-java-web-app/Tiltfile
@@ -1,12 +1,16 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
                " --namespace " + NAMESPACE +
-               " --yes --output yaml",
+    " --wait-timeout " + WAIT_TIMEOUT +
+    " --type " + TYPE +
+    " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     deps=['pom.xml', './target/classes'],
     container_selector='workload',

--- a/tanzu-java-web-app/Tiltfile_gradle_intellij
+++ b/tanzu-java-web-app/Tiltfile_gradle_intellij
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
                " --namespace " + NAMESPACE +
+               " --wait-timeout " + WAIT_TIMEOUT +
+               " --type " + TYPE +
                " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     container_selector='workload',

--- a/tanzu-java-web-app/Tiltfile_gradle_vscode
+++ b/tanzu-java-web-app/Tiltfile_gradle_vscode
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'tanzu-java-web-app',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
                " --namespace " + NAMESPACE +
+               " --wait-timeout " + WAIT_TIMEOUT +
+               " --type " + TYPE +
                " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     container_selector='workload',

--- a/weatherforecast-steeltoe/Tiltfile
+++ b/weatherforecast-steeltoe/Tiltfile
@@ -1,5 +1,7 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 NAME = "sample-app"
 
 k8s_custom_deploy(
@@ -8,6 +10,8 @@ k8s_custom_deploy(
             " --local-path " + LOCAL_PATH +
             " --build-env BP_DEBUG_ENABLED=true" +
             " --namespace " + NAMESPACE +
+            " --wait-timeout " + WAIT_TIMEOUT +
+            " --type " + TYPE +
             " --yes " +
             " -oyaml",
   delete_cmd="tanzu apps workload delete " + NAME + " --namespace " + NAMESPACE + " --yes",

--- a/where-for-dinner/where-for-dinner-api-gateway/Tiltfile
+++ b/where-for-dinner/where-for-dinner-api-gateway/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/where-for-dinner/where-for-dinner-availability/Tiltfile
+++ b/where-for-dinner/where-for-dinner-availability/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner-availability',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/where-for-dinner/where-for-dinner-crawler-python/Tiltfile
+++ b/where-for-dinner/where-for-dinner-crawler-python/Tiltfile
@@ -1,15 +1,16 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
-OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner-crawler',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
                " --local-path " + LOCAL_PATH +
                " --namespace " + NAMESPACE +
-               " --yes " +
-               OUTPUT_TO_NULL_COMMAND +
-               " && kubectl get workload where-for-dinner-crawler --namespace " + NAMESPACE + " -o yaml",
+               " --wait-timeout " + WAIT_TIMEOUT +
+               " --type " + TYPE +
+               " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes",
     deps=[''],
     container_selector='workload',

--- a/where-for-dinner/where-for-dinner-notify/Tiltfile
+++ b/where-for-dinner/where-for-dinner-notify/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner-notify',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/where-for-dinner/where-for-dinner-search-proc/Tiltfile
+++ b/where-for-dinner/where-for-dinner-search-proc/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner-search-proc',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],

--- a/where-for-dinner/where-for-dinner-search/Tiltfile
+++ b/where-for-dinner/where-for-dinner-search/Tiltfile
@@ -1,11 +1,15 @@
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
 
 k8s_custom_deploy(
     'where-for-dinner-search',
     apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
         " --local-path " + LOCAL_PATH +
         " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
         " --yes --output yaml",
     delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
     deps=['pom.xml', './target/classes'],


### PR DESCRIPTION
The vscode and intellij extensions will now pass the Tiltfile two new env vars: `WAIT_TIMEOUT` and `TYPE`.
This is to utilize the `--wait-timeout` and `--type` flags