### PR TITLE
Updating Where For Dinner to Spring Boot 3.1.2

### DIFF
--- a/where-for-dinner/where-for-dinner-api-gateway/pom.xml
+++ b/where-for-dinner/where-for-dinner-api-gateway/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
    <parent>
 	   <groupId>org.springframework.boot</groupId>
 	   <artifactId>spring-boot-starter-parent</artifactId>
-	   <version>3.1.1</version>
+	   <version>3.1.2</version>
 	   <relativePath />
    </parent>
 

--- a/where-for-dinner/where-for-dinner-api-gateway/pom.xml
+++ b/where-for-dinner/where-for-dinner-api-gateway/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
    <parent>
 	   <groupId>org.springframework.boot</groupId>
 	   <artifactId>spring-boot-starter-parent</artifactId>
-	   <version>3.0.7</version>
+	   <version>3.1.1</version>
 	   <relativePath />
    </parent>
 
@@ -18,7 +18,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 
 	<properties>
         <java.version>17</java.version>
-		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 	</properties>
 	<dependencyManagement>

--- a/where-for-dinner/where-for-dinner-api-gateway/src/main/resources/application.yaml
+++ b/where-for-dinner/where-for-dinner-api-gateway/src/main/resources/application.yaml
@@ -29,7 +29,6 @@ spring:
         uri: ${where-for-dinner.search.uri}
         predicates:
         - Path=/api/search/**      
-        - Host=where-for-dinner**.**
         filters:
         - TokenRelay=
         - RewritePath=/api/search(?<segment>/?.*), $\{segment}
@@ -38,7 +37,6 @@ spring:
         uri: ${where-for-dinner.availability.uri}
         predicates:
         - Path=/api/availability/** 
-        - Host=where-for-dinner**.**
         filters:
         - TokenRelay=
         - RewritePath=/api/availability(?<segment>/?.*), $\{segment}
@@ -46,12 +44,10 @@ spring:
       - id: where-for-dinner_ui_route
         uri: ${where-for-dinner.ui.uri}
         predicates:
-        - Host=where-for-dinner**.**
         - Path=/diningsearch
       - id: where-for-dinner_ui_route
         uri: ${where-for-dinner.ui.uri}
         predicates:
-        - Host=where-for-dinner**.**
         - Path=/**
 
 ---

--- a/where-for-dinner/where-for-dinner-availability/pom.xml
+++ b/where-for-dinner/where-for-dinner-availability/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-availability/pom.xml
+++ b/where-for-dinner/where-for-dinner-availability/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.7</version>
+		<version>3.1.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,11 +15,10 @@
 	<description>Where For Dinner service for storing and retriving establishment reservation openings.</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<spring-cloud-bindings.version>1.11.0</spring-cloud-bindings.version>		
 		<snakeyaml.version>1.33</snakeyaml.version>
-		<springdoc.version>2.1.0</springdoc.version>
-		<mariadb.version>1.1.4</mariadb.version>		
+		<springdoc.version>2.1.0</springdoc.version>	
 	</properties>
 	<dependencies>
 		<dependency>
@@ -61,7 +60,6 @@
         <dependency>
             <groupId>org.mariadb</groupId>
             <artifactId>r2dbc-mariadb</artifactId>
-            <version>${mariadb.version}</version>
         </dependency>	
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -81,6 +79,36 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>rabbitmq</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>mariadb</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>r2dbc</artifactId>
+		    <scope>test</scope>
+		</dependency>        										
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>

--- a/where-for-dinner/where-for-dinner-availability/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
+++ b/where-for-dinner/where-for-dinner-availability/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
@@ -1,0 +1,39 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfiguration 
+{
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public RabbitMQContainer rabbitMQContainer() {
+        return new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+    }
+    
+    @Profile("mysql")
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public MariaDBContainer<?> mySQLContainer() {
+        return new MariaDBContainer<>("mariadb:10.3.6");
+        
+    }
+    
+    @Profile("postgres")
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>("postgres:9.6.12");
+        
+    }
+}

--- a/where-for-dinner/where-for-dinner-availability/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerAvailabilityTestApplication.java
+++ b/where-for-dinner/where-for-dinner-availability/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerAvailabilityTestApplication.java
@@ -1,0 +1,11 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.SpringApplication;
+
+public class WhereForDinnerAvailabilityTestApplication 
+{
+    public static void main(String[] args) 
+    {
+        SpringApplication.from(WhereForDinnerAvailabilityApplication::main).with(TestContainerConfiguration.class).run(args);
+    }
+}

--- a/where-for-dinner/where-for-dinner-crawler/pom.xml
+++ b/where-for-dinner/where-for-dinner-crawler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-crawler/pom.xml
+++ b/where-for-dinner/where-for-dinner-crawler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.7</version>
+		<version>3.1.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-notify/pom.xml
+++ b/where-for-dinner/where-for-dinner-notify/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-notify/pom.xml
+++ b/where-for-dinner/where-for-dinner-notify/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.7</version>
+		<version>3.1.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -50,6 +50,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>rabbitmq</artifactId>
+		    <scope>test</scope>
+		</dependency>			
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/where-for-dinner/where-for-dinner-notify/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
+++ b/where-for-dinner/where-for-dinner-notify/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
@@ -1,0 +1,17 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.RabbitMQContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfiguration 
+{
+    @ServiceConnection
+    @Bean
+    public RabbitMQContainer rabbitMQContainer() {
+        return new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+    }
+    
+}

--- a/where-for-dinner/where-for-dinner-notify/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerNotifyTestApplication.java
+++ b/where-for-dinner/where-for-dinner-notify/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerNotifyTestApplication.java
@@ -1,0 +1,11 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.SpringApplication;
+
+public class WhereForDinnerNotifyTestApplication 
+{
+    public static void main(String[] args) 
+    {
+        SpringApplication.from(WhereForDinnerNotifyApplication::main).with(TestContainerConfiguration.class).run(args);
+    }
+}

--- a/where-for-dinner/where-for-dinner-search-proc/pom.xml
+++ b/where-for-dinner/where-for-dinner-search-proc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-search-proc/pom.xml
+++ b/where-for-dinner/where-for-dinner-search-proc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.7</version>
+		<version>3.1.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,7 +15,7 @@
 	<description>Where for Dinner search processor</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -44,6 +44,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>rabbitmq</artifactId>
+		    <scope>test</scope>
+		</dependency>					
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>

--- a/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
+++ b/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
@@ -121,6 +121,7 @@ spring:
 
   redis:
     ssl: false
+    port: 6379
 
   data:
     redis:
@@ -128,7 +129,7 @@ spring:
       host: ${spring.redis.host}
       password: ${spring.redis.password}
       port: ${spring.redis.port}
-      ssl: ${spring.redis.ssl}
+      ssl.eanbled: ${spring.redis.ssl}
   
 management:
   health:

--- a/where-for-dinner/where-for-dinner-search-proc/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
+++ b/where-for-dinner/where-for-dinner-search-proc/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
@@ -1,0 +1,28 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfiguration 
+{
+    @Bean
+    @ServiceConnection
+    public RabbitMQContainer rabbitMQContainer() {
+        return new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+    }
+    
+    @Profile("redis")
+    @Bean
+    @ServiceConnection(name="redis")
+    public GenericContainer<?> redisContainer() {
+        final var redisContainer = new GenericContainer<>("redis:7.0.12-alpine");
+        redisContainer.addExposedPort(6379);
+        
+    	return redisContainer;
+    }
+}

--- a/where-for-dinner/where-for-dinner-search-proc/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerSearchProcTestApplication.java
+++ b/where-for-dinner/where-for-dinner-search-proc/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerSearchProcTestApplication.java
@@ -1,0 +1,12 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.SpringApplication;
+
+
+public class WhereForDinnerSearchProcTestApplication 
+{
+    public static void main(String[] args) 
+    {
+        SpringApplication.from(WhereForDinnerSearchProcApplication::main).with(TestContainerConfiguration.class).run(args);
+    }
+}

--- a/where-for-dinner/where-for-dinner-search/pom.xml
+++ b/where-for-dinner/where-for-dinner-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.1</version>
+		<version>3.1.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/where-for-dinner/where-for-dinner-search/pom.xml
+++ b/where-for-dinner/where-for-dinner-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.7</version>
+		<version>3.1.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -15,12 +15,11 @@
 	<description>Demo</description>		
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<revision>0.0.1-SNAPSHOT</revision>		
 		<spring-cloud-bindings.version>1.11.0</spring-cloud-bindings.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<springdoc.version>2.1.0</springdoc.version>
-		<mariadb.version>1.1.4</mariadb.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -79,9 +78,45 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>r2dbc</artifactId>
+		    <scope>test</scope>
+		</dependency> 		
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>rabbitmq</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>mariadb</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+		<dependency>
+		    <groupId>org.testcontainers</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <scope>test</scope>
+		</dependency>	
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>test</scope>
+        </dependency>		
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
@@ -94,7 +129,6 @@
         <dependency>
             <groupId>org.mariadb</groupId>
             <artifactId>r2dbc-mariadb</artifactId>
-            <version>${mariadb.version}</version>
         </dependency>	
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/where-for-dinner/where-for-dinner-search/src/main/java/com/java/example/tanzu/wherefordinner/WhereForDinnerResApplication.java
+++ b/where-for-dinner/where-for-dinner-search/src/main/java/com/java/example/tanzu/wherefordinner/WhereForDinnerResApplication.java
@@ -2,10 +2,8 @@ package com.java.example.tanzu.wherefordinner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
 @SpringBootApplication
-@EnableR2dbcRepositories("com.java.example.tanzu.wherefordinner.repository")
 public class WhereForDinnerResApplication {
 
 	public static void main(String[] args) {

--- a/where-for-dinner/where-for-dinner-search/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
+++ b/where-for-dinner/where-for-dinner-search/src/test/java/com/java/example/tanzu/wherefordinner/TestContainerConfiguration.java
@@ -1,0 +1,39 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfiguration 
+{
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public RabbitMQContainer rabbitMQContainer() {
+        return new RabbitMQContainer("rabbitmq:3.7.25-management-alpine");
+    }
+    
+    @Profile("mysql")
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public MariaDBContainer<?> mySQLContainer() {
+        return new MariaDBContainer<>("mariadb:10.3.6");
+        
+    }
+    
+    @Profile("postgres")
+	@RestartScope
+    @ServiceConnection
+    @Bean
+    public PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>("postgres:9.6.12");
+        
+    }
+}

--- a/where-for-dinner/where-for-dinner-search/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerResTestApplication.java
+++ b/where-for-dinner/where-for-dinner-search/src/test/java/com/java/example/tanzu/wherefordinner/WhereForDinnerResTestApplication.java
@@ -1,0 +1,11 @@
+package com.java.example.tanzu.wherefordinner;
+
+import org.springframework.boot.SpringApplication;
+
+public class WhereForDinnerResTestApplication {
+	
+    public static void main(String[] args) 
+    {
+        SpringApplication.from(WhereForDinnerResApplication::main).with(TestContainerConfiguration.class).run(args);
+    }
+}

--- a/where-for-dinner/where-for-dinner-search/src/test/resources/application.yml
+++ b/where-for-dinner/where-for-dinner-search/src/test/resources/application.yml
@@ -16,3 +16,21 @@ spring:
       bindings: 
         submittedSearches-out-0: 
           destination: where-for-dinner-search-criteria
+---
+
+spring:
+  config.activate.on-profile: mysql
+  
+  sql.init.platform: mysql
+  
+  r2dbc: 
+    #Default properties to work with MariaDB driver
+    properties.sslMode: TRUST  
+    properties.tlsVersion: TLSv1.2
+    
+---
+
+spring:
+  config.activate.on-profile: postgres
+  
+  sql.init.platform: postgresql


### PR DESCRIPTION
Updating Spring Boot version to 3.1.2
Adding test application classes to utilize new 3.1.0 TestContainer features when in IDE and command line dev mode.