### PR TITLE
Add 'autoscaling.knative.dev/minScale: 1' annotation to tanzu-java-web-app native workload

### DIFF
--- a/tanzu-java-web-app/config/workload-native.yaml
+++ b/tanzu-java-web-app/config/workload-native.yaml
@@ -45,6 +45,10 @@ spec:
     value: "8081"
   - name: SERVER_PORT
     value: "8080"
+  params:
+    - name: annotations
+      value:
+        autoscaling.knative.dev/minScale: "1"
   source:
     git:
       url: <https URL for your generated project's Git repository>


### PR DESCRIPTION
Without it, the k8s deployment is created with 'replicas: 0'.