### PR TITLE
add warning to the function accelerators

### DIFF
--- a/java-function/README.md
+++ b/java-function/README.md
@@ -1,5 +1,7 @@
 # Java Function
 
+>⚠️ Following Acceletaror is deprecated and will no longer be officially maintained by VMware for TAP 1.7 and up. Users should not use this accelerator anymore. If you want to use a function java accelerator we recommend using the [Spring Cloud Serverless](../spring-cloud-serverless) accelerator and add the Spring Cloud Function Dependency to the project.
+
 This repo contains a simple Java Function that can be deployed as a TAP workload.
 
 This function utilizes the buildpacks provided by VMware's open-source [Function Buildpacks for Knative](https://github.com/vmware-tanzu/function-buildpacks-for-knative) project.

--- a/node-function/README.md
+++ b/node-function/README.md
@@ -1,5 +1,7 @@
 # Node Function
 
+>⚠️ Following Acceletaror is deprecated and will no longer be officially maintained by VMware for TAP 1.7 and up. Users should not use this accelerator anymore. If you want to use a function node accelerator we recommend using the [Node Express](../node-express) accelerator and add the neccesary dependencies.
+
 This repo contains a simple Node Function that can be deployed as a TAP workload.
 
 This function utilizes the buildpacks provided by VMware's open-source [Function Buildpacks for Knative](https://github.com/vmware-tanzu/function-buildpacks-for-knative) project.

--- a/python-function/README.md
+++ b/python-function/README.md
@@ -1,5 +1,7 @@
 # Python Function
 
+>⚠️ Following Acceletaror is deprecated and will no longer be officially maintained by VMware for TAP 1.7 and up. Users should not use this accelerator anymore. If you want to use a function python accelerator we recommend using the [Python Web App](../python-web-app) accelerator and add the neccesary dependencies.
+
 This repo contains a simple Python Function that can be deployed as a TAP workload.
 
 This function utilizes the buildpacks provided by VMware's open-source [Function Buildpacks for Knative](https://github.com/vmware-tanzu/function-buildpacks-for-knative) project.


### PR DESCRIPTION
The function buildpacks are deprecated from TAP 1.7 and up. 