### PR TITLE
fix: added securityContext so the pipeline runs in restricted environments

### DIFF
--- a/ns-provisioner-samples/testing-scanning-supplychain-multiple-scanners/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-multiple-scanners/tekton-pipeline-java.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: gradle

--- a/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-golang.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-golang.yaml
@@ -29,6 +29,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: golang

--- a/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-java.yaml
@@ -29,6 +29,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: gradle

--- a/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-nodejs.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-parameterized/tekton-pipeline-nodejs.yaml
@@ -29,6 +29,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: nodejs

--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-golang.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-golang.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: golang

--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-java.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: gradle

--- a/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-nodejs.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain-polyglot/tekton-pipeline-nodejs.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: nodejs

--- a/ns-provisioner-samples/testing-scanning-supplychain/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-scanning-supplychain/tekton-pipeline-java.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: gradle

--- a/ns-provisioner-samples/testing-supplychain/tekton-pipeline-java.yaml
+++ b/ns-provisioner-samples/testing-supplychain/tekton-pipeline-java.yaml
@@ -28,6 +28,16 @@ spec:
         params:
           - name: source-url
           - name: source-revision
+        stepTemplate:
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
         steps:
           - name: test
             image: gradle


### PR DESCRIPTION
This PR adds the following `securityContext` to all tekton pipeline examples in Namespace provisioner samples folder so the pipeline can run in restricted tkgm environments.
```yaml
        stepTemplate:
          securityContext:
            allowPrivilegeEscalation: false
            runAsUser: 1000
            runAsNonRoot: true
            capabilities:
              drop:
                - ALL
            seccompProfile:
              type: RuntimeDefault
```