### PR TITLE
feat: Add namespace provisioner samples for setting up Tanzu Supply Chains

### DIFF
--- a/ns-provisioner-samples/tanzu-supply-chain/buildpack-build-clusterrolebinding.yaml
+++ b/ns-provisioner-samples/tanzu-supply-chain/buildpack-build-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: #@ "buildpack-build-workload-rb-" + data.values.name
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: buildpack-build-workload-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: #@ data.values.name

--- a/ns-provisioner-samples/tanzu-supply-chain/oci-store-credentials.yaml
+++ b/ns-provisioner-samples/tanzu-supply-chain/oci-store-credentials.yaml
@@ -1,0 +1,19 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:json", "json")
+#@ load("@ytt:base64", "base64")
+#@ def generate_dockerconfigjson():
+#@   dcj = {"auths": {}}
+#@   up = {"username": data.values.imported.tanzusupplychain.ocistore.username, "password": data.values.imported.tanzusupplychain.ocistore.password}
+#@   dcj["auths"][data.values.imported.tanzusupplychain.ocistore.server] = up
+#@   return base64.encode(json.encode(dcj))
+#@ end
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: #@ generate_dockerconfigjson()
+kind: Secret
+metadata:
+  name: oci-store-credentials
+  annotations:
+    tekton.dev/docker-0: #@ data.values.imported.tanzusupplychain.ocistore.server + "/" + data.values.imported.tanzusupplychain.ocistore.repository
+type: kubernetes.io/dockerconfigjson

--- a/ns-provisioner-samples/tanzu-supply-chain/oci-store.yaml
+++ b/ns-provisioner-samples/tanzu-supply-chain/oci-store.yaml
@@ -1,0 +1,10 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oci-store
+stringData:
+  repository: #@ data.values.imported.tanzusupplychain.ocistore.repository
+  server: #@ data.values.imported.tanzusupplychain.ocistore.server
+type: Opaque


### PR DESCRIPTION
This MR adds a sample folder called tanzu-supply-chain in Namespace provisioner samples which creates 3 things
* OCI store secret
* Credentials for that OCI store 
* ClusterRoleBinding for buildpack build component