### PR TITLE
java-server-side-ui: include webjars in gradle build file

### DIFF
--- a/java-server-side-ui/build.gradle.kts
+++ b/java-server-side-ui/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.webjars:webjars-locator-core")
+    implementation("org.webjars:bootstrap:5.2.0")
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/java-server-side-ui/pom.xml
+++ b/java-server-side-ui/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>webjars-locator-core</artifactId>
-            <version>0.56</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
- align build.gradle.kts with pom.xml, using webjars and webjars bootstrap
- unpin webjars-locator-core version in pom.xml, the dependency is managed by spring boot dependency management