### PR TITLE
Update wfd services to the v1 APIs

### DIFF
--- a/where-for-dinner/spaces-beta3-deployment/aws/awsServices.yaml
+++ b/where-for-dinner/spaces-beta3-deployment/aws/awsServices.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
+apiVersion: services.tanzu.vmware.com/v1
 kind: PreProvisionedService
 metadata:
   name: where-for-dinner-mysql
@@ -11,7 +11,7 @@ spec:
     secretRef: 
       name: where-for-dinner-mysql
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
+apiVersion: services.tanzu.vmware.com/v1
 kind: PreProvisionedService
 metadata:
   name: where-for-dinner-rabbitmq
@@ -23,97 +23,97 @@ spec:
     secretRef: 
       name: where-for-dinner-rabbitmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-availability-mysql
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: availability
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-mysql
     connectorName: read-write
   alias: db
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-mysql
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-search
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-mysql
     connectorName: read-write
   alias: db
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-availability-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: availability
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-rabbitmq
     connectorName: read-write
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-search
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-rabbitmq
     connectorName: read-write
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-proc-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: search-proc
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-rabbitmq
     connectorName: read-write
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-notify-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-notify
-  serviceInstanceRef:
-    apiVersion: services.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: services.tanzu.vmware.com
     kind: PreProvisionedService
     name: where-for-dinner-rabbitmq
     connectorName: read-write

--- a/where-for-dinner/spaces-beta3-deployment/bitnami/bitnamiServices.yaml
+++ b/where-for-dinner/spaces-beta3-deployment/bitnami/bitnamiServices.yaml
@@ -13,92 +13,92 @@ metadata:
 spec:
   replicas: 1
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-availability-mysql
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: availability
-  serviceInstanceRef:
-    apiVersion: bitnami.database.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.database.tanzu.vmware.com
     kind: MySQLInstance
     name: where-for-dinner-mysql
   alias: db
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-mysql
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-search
-  serviceInstanceRef:
-    apiVersion: bitnami.database.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.database.tanzu.vmware.com
     kind: MySQLInstance
     name: where-for-dinner-mysql
   alias: db
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-availability-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: availability
-  serviceInstanceRef:
-    apiVersion: bitnami.messaging.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.messaging.tanzu.vmware.com
     kind: RabbitmqCluster
     name: where-for-dinner-rabbitmq
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-search
-  serviceInstanceRef:
-    apiVersion: bitnami.messaging.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.messaging.tanzu.vmware.com
     kind: RabbitmqCluster
     name: where-for-dinner-rabbitmq
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-search-proc-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: search-proc
-  serviceInstanceRef:
-    apiVersion: bitnami.messaging.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.messaging.tanzu.vmware.com
     kind: RabbitmqCluster
     name: where-for-dinner-rabbitmq
   alias: rmq
 ---
-apiVersion: services.tanzu.vmware.com/v1alpha1
-kind: ServiceInstanceBinding
+apiVersion: services.tanzu.vmware.com/v1
+kind: ServiceBinding
 metadata:
   name: where-for-dinner-notify-rabbitmq
 spec:
   targetRef:
-    apiVersion: apps/v1
+    apiGroup: apps
     kind: Deployment
     name: where-for-dinner-notify
-  serviceInstanceRef:
-    apiVersion: bitnami.messaging.tanzu.vmware.com/v1alpha1
+  serviceRef:
+    apiGroup: bitnami.messaging.tanzu.vmware.com
     kind: RabbitmqCluster
     name: where-for-dinner-rabbitmq
   alias: rmq


### PR DESCRIPTION
## About

**do not merge**

* Updates the wfd services to use v1 of the services.tanzu.vmware.com API
* I am assuming we don't want to merge this into the `wfd-spaces-beta3` branch as the v1 API is not available in beta3
* I am opening this MR in draft to ready the changes that will be required for the wfd services config for GA