### PR TITLE
Updating crawler server to user service port 8080.

### DIFF
--- a/where-for-dinner/templates/workloads.yaml
+++ b/where-for-dinner/templates/workloads.yaml
@@ -428,7 +428,7 @@ spec:
   params:
   - name: ports
     value:
-    - port: 80
+    - port: 8080
       containerPort: 8080
       name: http
   serviceClaims: #@ buildServiceClaimsBinding(False, False, False, False, True, True)   
@@ -460,7 +460,7 @@ spec:
   params:
   - name: ports
     value:
-    - port: 80
+    - port: 8080
       containerPort: 8080
       name: http         
   resources:     

--- a/where-for-dinner/where-for-dinner-crawler-python/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-crawler-python/config/workload.yaml
@@ -11,7 +11,7 @@ spec:
   params:
   - name: ports
     value:
-    - port: 80
+    - port: 8080
       containerPort: 8080
       name: http      
   resources:     

--- a/where-for-dinner/where-for-dinner-crawler/config/workload.yaml
+++ b/where-for-dinner/where-for-dinner-crawler/config/workload.yaml
@@ -12,7 +12,7 @@ spec:
   params:
   - name: ports
     value:
-    - port: 80
+    - port: 8080
       containerPort: 8080
       name: http      
   resources:     

--- a/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
+++ b/where-for-dinner/where-for-dinner-search-proc/src/main/resources/application.yml
@@ -37,6 +37,10 @@ eureka:
       
 where-for-dinner:
 
+  crawler:
+    service:
+      identifier: 'http://where-for-dinner-crawler:8080'
+
   randomsearcher:
     establishments:
     - diningName: Bristol
@@ -180,7 +184,12 @@ spring:
   config.activate.on-profile: eureka
   
   cloud.loadbalancer.enabled: true
-  
+
+where-for-dinner:
+
+  crawler:
+    service:
+      identifier: 'http://where-for-dinner-crawler'  
   
 eureka:
   client:


### PR DESCRIPTION
Search processor configuration defaults to calling the crawler service on port 8080.  When Eureka is enabled, the configuration excludes the port and lets the service registry take over.