### PR TITLE
Turning on TSL for config server instance in Where For Dinner.

### DIFF
--- a/where-for-dinner/templates/configServerInstance.yaml
+++ b/where-for-dinner/templates/configServerInstance.yaml
@@ -9,6 +9,8 @@ metadata:
   labels:
     services.apps.tanzu.vmware.com/class: #@ data.values.springCloudServices.configServer.configServiceName
 spec:
+  tls:
+    activated: true
   backends:
   - git:
       uri: #@ data.values.springCloudServices.configServer.configRepoURL


### PR DESCRIPTION
Per PM request for best practices, the config server TLS option is explicitly being turned on.