### PR TITLE
Enabling the SMTP Gateway web interface to allow for scraping.

### DIFF
--- a/spring-smtp-gateway/smtp-gateway/src/main/java/com/java/example/smtpmq/gateway/boot/SmtpGatewayApplication.java
+++ b/spring-smtp-gateway/smtp-gateway/src/main/java/com/java/example/smtpmq/gateway/boot/SmtpGatewayApplication.java
@@ -20,7 +20,6 @@ public class SmtpGatewayApplication implements CommandLineRunner
 	public static void main(String[] args) 
 	{
 		new SpringApplicationBuilder(SmtpGatewayApplication.class)
-                .web(WebApplicationType.NONE)
                 .run(args);		
     }	
 	


### PR DESCRIPTION
Because the spring conventions are detecting the actuator library, the web interface also needs to be enabled for the added probes to work corrects; otherwise K8s will kill the app because it doesn't think the app is responsive (probes failing).