### PR TITLE
Update httproute for ingress v2

### DIFF
--- a/where-for-dinner/.tanzu/config/k8sGatewayRoutes.yaml
+++ b/where-for-dinner/.tanzu/config/k8sGatewayRoutes.yaml
@@ -8,18 +8,12 @@ metadata:
     healthcheck.gslb.tanzu.vmware.com/port: "80"
 spec:
   parentRefs:
-  - group: gateway.networking.k8s.io
-    kind: Gateway
-    name: default-gateway
-    sectionName: http-where-for-dinner
+  - group: networking.tanzu.vmware.com
+    kind: Entrypoint
+    name: main 
   rules:
   - backendRefs:
     - group: ""
       kind: Service
       name: spring-cloud-gateway
       port: 80
-      weight: 1
-    matches:
-    - path:
-        type: PathPrefix
-        value: /


### PR DESCRIPTION
Update the httproute on the where-for-dinner sample app used as part of the quick start for Tanzu Platform for Kubernetes to use ingress v2 spec.