### PR TITLE
Fix path expected by dependency of metadata-store-cert secret

### DIFF
--- a/ns-provisioner-samples/testing-scanning-v2-supplychain/metadata-store-access.yaml
+++ b/ns-provisioner-samples/testing-scanning-v2-supplychain/metadata-store-access.yaml
@@ -11,7 +11,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  caCrt: #@ data.values.imported.metadataStore.caCrt
+  ca.crt: #@ data.values.imported.metadataStore.caCrt
 kind: Secret
 metadata:
   name: metadata-store-cert


### PR DESCRIPTION
Secret created by provisioner is meant to have the key `ca.crt`. See in docs-tap:
https://github.gwd.broadcom.net/TNZ/docs-tap/blob/1-12-6/scst-scan/creating-scan-policy-template.hbs.md?plain=1#L163